### PR TITLE
Use `cached` to cache `Middleware` requests

### DIFF
--- a/crates/middleware/Cargo.toml
+++ b/crates/middleware/Cargo.toml
@@ -13,3 +13,4 @@ tokio-stream = {version = "0.1.14", features = ["sync"]}
 terraphim_types = { path = "../../terraphim_types" }
 terraphim_pipeline = { path = "../terraphim_pipeline" }
 thiserror = "1.0.56"
+cached = { version = "0.47.0", features = ["async", "serde", "ahash"] }

--- a/crates/middleware/src/main.rs
+++ b/crates/middleware/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     // let articles_cached_left = run_ripgrep_service_and_index(config_state.clone(),needle.clone(), haystack).await;
     // println!("articles_cached_left: {:#?}", articles_cached_left.clone());
 
-    let articles_cached = search_haystacks(config_state.clone(), search_query.clone()).await;
+    let articles_cached = search_haystacks(config_state.clone(), search_query.clone()).await?;
     let docs: Vec<IndexedDocument> = config_state
         .search_articles(search_query)
         .await


### PR DESCRIPTION
This enables caching support for `index` requests using `cached`.

In comparison to `memoize`, `cached` has a few advantages for our use-case:

- `memoize` doesn't support async functions. See https://github.com/dermesser/memoize/issues/27
- Return types in `memoize` need to be `Clone`, which is not the case for `Error` and it's not trivial to change that, because upstream errors like `serde_json::Error` and `std::io::Error` are not `Clone`. There are ways around it, (e.g. by using `String` as error types or implementing a `newtype`, but let's see if we can avoid that.

`cached` supports these properties out of the box. The only caveat is, that `self` arguments are not supported, which is why I moved the `HashMap` generation into a separate function (`index_inner`).

To compare with `memoize`, I've created another branch [here](https://github.com/terraphim/terraphim-ai/compare/main...mre:terraphim-ai:feature/memoize-requests?expand=1). It's just for reference to compare both crates. My recommendation is to go forward with `cached` for the reasons above.

If we want, we can tweak the [`#[cached]` parameters](https://docs.rs/cached/latest/cached/proc_macro/attr.cached.html) as well. Can also happen in a separate PR.

Fixes #20.