### PR TITLE
Add basic README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,56 @@
 # Terraphim AI Assistant
 
-Terraphim is a privacy-preserving AI assistant.
+Terraphim is a privacy-first AI assistant that works for you under your complete
+control. It begins as a local search engine, which can be configured to search
+for different types of content, such as StackOverflow, GitHub, and the local
+filesystem with a pre-defined folder, including Markdown Files. We utilize
+modern algorithms for AI/ML, data fusion, and distributed communication
+techniques to operate AI assistants on the user's hardware, including unused
+mobile devices.
+
+It operates on local infrastructure and works exclusively for the owner's
+benefit.
+
+<div class="vimeo is-flex is-justify-content-center is-align-items-center">
+    <iframe
+        width="848" height="510"
+        title="vimeo-player" 
+        src="https://player.vimeo.com/video/854283350" 
+        frameborder="0" 
+        allowfullscreen>
+    </iframe>
+</div>
+
+# Why Terraphim?
+
+There are growing concerns about the privacy of data and the sharing of
+individuals' data across an ever-growing list of services, some of which have a
+questionable data ethics policy (e.g., Miro policy stated they could market any
+user content without permission as of Jan 2020).
+
+**Individuals** struggle to find relevant information in different knowledge repositories: [[1]](https://www.coveo.com/en/resources/reports/relevance-report-workplace),
+[[2]](https://cottrillresearch.com/various-survey-statistics-workers-spend-too-much-time-searching-for-information/),
+[[3]](https://www.forbes.com/sites/forbestechcouncil/2019/12/17/reality-check-still-spending-more-time-gathering-instead-of-analyzing/):
+personal ones like Roam Research/Obsidian/Coda/Notion, team-focused ones like
+Jira/Confluence/Sharepoint, or public
+[[4]](https://www.theatlantic.com/technology/archive/2021/06/the-internet-is-a-collective-hallucination/619320/).
+
+# Follow us
+
+[![Discourse users](https://img.shields.io/discourse/users?server=https%3A%2F%2Fterraphim.discourse.group)](https://terraphim.discourse.group) 
+[![Discord](https://img.shields.io/discord/852545081613615144?label=Discord&logo=Discord)](https://discord.gg/VPJXB6BGuY)
+
+# Terminology
+
+- **Role**: A role is a set of settings that define the default behavior of the AI assistant. For example, a developer role will search for code-related content, while a father role will search for parenting-related content.
+- **Rolegraph**: A structure for ingesting documents into Terraphim.
+
+# Why "Terraphim"?
+
+Alex Mikhalev was inspired by the [Relict series][relict] of science fiction
+novels by [Vasiliy Golovachev](https://en.wikipedia.org/wiki/Vasili_Golovachov),
+where Terraphim is an artificial intelligence living inside a spacesuit (part of
+an exocortex).
+
+
+[relict]: https://www.goodreads.com/en/book/show/196710046

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# terraphim-ai
-This is mono repo for Terraphim AI assistant; no submodules anymore
+# Terraphim AI Assistant
 
+Terraphim is a privacy-preserving AI assistant.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terraphim AI Assistant
 
 Terraphim is a privacy-first AI assistant that works for you under your complete
-control. It begins as a local search engine, which can be configured to search
+control and is fully deterministic. It begins as a local search engine, which can be configured to search
 for different types of content, such as StackOverflow, GitHub, and the local
 filesystem with a pre-defined folder, including Markdown Files. We utilize
 modern algorithms for AI/ML, data fusion, and distributed communication
@@ -25,13 +25,12 @@ benefit.
 
 There are growing concerns about the privacy of data and the sharing of
 individuals' data across an ever-growing list of services, some of which have a
-questionable data ethics policy (e.g., Miro policy stated they could market any
-user content without permission as of Jan 2020).
+questionable data ethics policy.
 
 **Individuals** struggle to find relevant information in different knowledge repositories: [[1]](https://www.coveo.com/en/resources/reports/relevance-report-workplace),
 [[2]](https://cottrillresearch.com/various-survey-statistics-workers-spend-too-much-time-searching-for-information/),
 [[3]](https://www.forbes.com/sites/forbestechcouncil/2019/12/17/reality-check-still-spending-more-time-gathering-instead-of-analyzing/):
-personal ones like Roam Research/Obsidian/Coda/Notion, team-focused ones like
+personal ones like Roam Research/Obsidian/Coda/Notion, and team-focused ones like
 Jira/Confluence/Sharepoint, or public
 [[4]](https://www.theatlantic.com/technology/archive/2021/06/the-internet-is-a-collective-hallucination/619320/).
 


### PR DESCRIPTION
This pull request adds a basic `README.md` file to the repository. The README provides an overview of the Terraphim AI Assistant, including its purpose, features, and benefits. It also includes links to the project's Discourse forum and Discord server for further engagement. Additionally, the README explains key terminology used in the project, such as roles and rolegraphs. Finally, it shares the inspiration behind the name "Terraphim" and provides a reference to the Relict series of science fiction novels.

We can extend the document in the future (e.g. we should extend the terminology section) but I think it's a start.