### PR TITLE
WIP: Axum start before test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5653,6 +5653,7 @@ dependencies = [
  "axum 0.6.20",
  "axum-extra",
  "clap 4.4.18",
+ "lazy_static",
  "log",
  "mime_guess",
  "persistence",

--- a/terraphim_server/Cargo.toml
+++ b/terraphim_server/Cargo.toml
@@ -32,5 +32,6 @@ mime_guess = "2.0.4"
 tower = { version = "0.4", features = ["util"] }
 rust-embed = { version = "8.2.0", features = ["axum", "axum-ex","mime-guess"] }
 
+
 [dev-dependencies]
-lazy_static = "1.4.0"
+ctor = "0.2.6"

--- a/terraphim_server/Cargo.toml
+++ b/terraphim_server/Cargo.toml
@@ -31,3 +31,6 @@ utoipa-swagger-ui = { features = ["axum"], version = "4.0.0" }
 mime_guess = "2.0.4"
 tower = { version = "0.4", features = ["util"] }
 rust-embed = { version = "8.2.0", features = ["axum", "axum-ex","mime-guess"] }
+
+[dev-dependencies]
+lazy_static = "1.4.0"

--- a/terraphim_server/src/main.rs
+++ b/terraphim_server/src/main.rs
@@ -84,12 +84,39 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use reqwest::{Client, StatusCode};
-    use terraphim_config::TerraphimConfig;
+    use terraphim_types as types;
     use tokio::test;
+    use std::net::SocketAddr;
+    use terraphim_server::axum_server;
 
+    lazy_static::lazy_static! {
+        static ref SERVER: String = {
+            // let port = portpicker::pick_unused_port().expect("failed to find unused port");
+            let port = 8000;
+            let addr = SocketAddr::from(([127, 0, 0, 1], port));
+
+            tokio::spawn(async move {
+                let config_state = types::ConfigState::new().await.unwrap();
+                if let Err(e) = axum_server(addr, config_state).await {
+                    println!("Failed to start axum server: {e:?}");
+                }
+                std::thread::sleep(std::time::Duration::from_secs(2));
+                println!("Server started");
+            });
+    
+            // Wait for the server to start
+            
+    
+            // Store the server address in an environment variable so the tests can use it
+            std::env::set_var("TEST_SERVER_URL", format!("http://{}", addr));
+            addr.to_string()
+        };
+    }
     #[test]
     async fn test_search_articles() {
-        let response = reqwest::get("http://localhost:8000/articles/search?search_term=trained%20operators%20and%20maintainers&skip=0&limit=10&role=system%20operator").await.unwrap();
+        let url = format!("http://{}/articles/search?search_term=trained%20operators%20and%20maintainers&skip=0&limit=10&role=system%20operator",&*SERVER);
+        println!("url: {:?}", url);
+        let response = reqwest::get(url).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         // You can also test the response body if you want:
         // let body = response.text().await.unwrap();
@@ -161,7 +188,10 @@ mod tests {
     }
     #[test]
     async fn test_get_config() {
-        let response = reqwest::get("http://localhost:8000/config/").await.unwrap();
+        let _ = &*SERVER;
+        let url = format!("http://{}/api/config/",&*SERVER);
+        println!("url: {:?}", url);
+        let response = reqwest::get(url).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         // You can also test the response body if you want:
         // let body = response.text().await.unwrap();
@@ -171,6 +201,7 @@ mod tests {
     /// test update config
     #[test]
     async fn test_post_config() {
+        use terraphim_config::TerraphimConfig;
         let response = reqwest::get("http://localhost:8000/config/").await.unwrap();
         let orig_config: TerraphimConfig = response.json().await.unwrap();
         println!("orig_config: {:?}", orig_config);


### PR DESCRIPTION
This is for discussion - I am trying to make sure Axum server starts before running tests.
I added lazy_static and modified two tests test_get_config and test_search_articles, both still fail with connection error. 
What's wrong?