### PR TITLE
Front end fixes

### DIFF
--- a/desktop/src-tauri/src/cmd.rs
+++ b/desktop/src-tauri/src/cmd.rs
@@ -51,7 +51,7 @@ pub async fn search(
 ) -> Result<Vec<Article>, TerraphimTauriError> {
     println!("Search called with {:?}", search_query);
     let current_config_state = config_state.inner().clone();
-    search_haystacks(current_config_state.clone(), search_query.clone())
+    let articles_cached=search_haystacks(current_config_state.clone(), search_query.clone())
         .await
         .context("Failed to search articles")
         .unwrap();
@@ -59,7 +59,7 @@ pub async fn search(
         .search_articles(search_query)
         .await
         .expect("Failed to search articles");
-    let articles = merge_and_serialize(current_config_state.articles_cached, docs).unwrap();
+    let articles = merge_and_serialize(articles_cached, docs).unwrap();
 
     Ok(articles)
 }

--- a/desktop/src/lib/ThemeSwitcher.svelte
+++ b/desktop/src/lib/ThemeSwitcher.svelte
@@ -21,15 +21,15 @@
                   return config;
               });
               roles.update(roles => {
-              roles = data.roles;
+              roles = $configStore["roles"];
               return roles;
             });
-              // configStore["roles"] = res.roles;
-              // FIXME: set to default role
-              role.set($configStore["roles"]["default"]);
-              theme.set($role['theme']);
+              
+              const role_value=$configStore["default_role"].toLowerCase();
+              role.set(role_value);
+              theme.set($roles[$role]['theme']);
               console.log('Role', $role);
-              theme.set(configStore[$role]['theme']);
+              console.log('Theme', $theme);
 
           })
             .catch((e) => console.error(e))


### PR DESCRIPTION
Final front-end fixes - revert some of articles_cache. 
It may be worth splitting #45 into articles_cache for the Axum server only - no need for maintaining article cache beyond cached macro for local search. 
