### PR TITLE
Move shared logic to terraphim_service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,6 +5172,7 @@ dependencies = [
  "persistence",
  "portpicker",
  "serde",
+ "service",
  "tauri",
  "tauri-build",
  "terraphim_config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,6 +4499,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "service"
+version = "0.1.0"
+dependencies = [
+ "opendal",
+ "persistence",
+ "terraphim_config",
+ "terraphim_middleware",
+ "terraphim_settings",
+ "terraphim_types",
+ "thiserror",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5278,6 +5291,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "service",
  "static-files",
  "tempfile",
  "terraphim_automata",

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -299,13 +299,13 @@ impl ConfigState {
     }
 
     /// Search articles in rolegraph using the search query
-    pub async fn search_articles(&self, search_query: SearchQuery) -> Vec<IndexedDocument> {
+    pub async fn search_articles(&self, search_query: &SearchQuery) -> Vec<IndexedDocument> {
         println!("search_articles: {:#?}", search_query);
         let current_config_state = self.config.lock().await.clone();
         let default_role = current_config_state.default_role.clone();
 
         // if role is not provided, use the default role from the config
-        let role = search_query.role.unwrap_or(default_role);
+        let role = search_query.role.clone().unwrap_or(default_role);
         log::debug!("Role for search_articles: {:#?}", role);
 
         let role = role.to_lowercase();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -300,7 +300,7 @@ impl ConfigState {
 
     /// Search articles in rolegraph using the search query
     pub async fn search_articles(&self, search_query: &SearchQuery) -> Vec<IndexedDocument> {
-        println!("search_articles: {:#?}", search_query);
+        log::debug!("search_articles: {:?}", search_query);
         let current_config_state = self.config.lock().await.clone();
         let default_role = current_config_state.default_role.clone();
 

--- a/crates/middleware/src/thesaurus/mod.rs
+++ b/crates/middleware/src/thesaurus/mod.rs
@@ -146,7 +146,7 @@ impl LogseqService {
     /// https://docs.rs/grep-printer/0.2.1/grep_printer/struct.JSON.html
     pub async fn get_raw_messages(&self, needle: &str, haystack: &Path) -> Result<Vec<Message>> {
         let haystack = haystack.to_string_lossy().to_string();
-        println!("Running logseq with needle `{needle}` and haystack `{haystack}`");
+        log::trace!("Running logseq with needle `{needle}` and haystack `{haystack}`");
 
         // Merge the default arguments with the needle and haystack
         let args: Vec<String> = vec![needle.to_string(), haystack]

--- a/crates/middleware/src/thesaurus/mod.rs
+++ b/crates/middleware/src/thesaurus/mod.rs
@@ -39,9 +39,9 @@ use crate::Error;
 
 pub async fn create_thesaurus_from_haystack(
     config_state: ConfigState,
-    search_query: SearchQuery,
+    search_query: &SearchQuery,
 ) -> Result<()> {
-    let role_name = search_query.role.unwrap_or_default();
+    let role_name = search_query.role.clone().unwrap_or_default();
 
     let config = config_state.config.lock().await;
     let roles = config.roles.clone();

--- a/crates/middleware/tests/ripgrep.rs
+++ b/crates/middleware/tests/ripgrep.rs
@@ -24,7 +24,7 @@ mod tests {
         let cached_articles = search_haystacks(config_state.clone(), search_query.clone()).await?;
         let docs: Vec<IndexedDocument> = config_state.search_articles(search_query).await;
         let articles = merge_and_serialize(cached_articles, docs);
-        log::trace!("Final articles: {articles:?}");
+        log::debug!("Final articles: {articles:?}");
 
         Ok(())
     }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "service"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+persistence = { path = "../persistence" }
+terraphim_config = { path = "../config" }
+terraphim_middleware = { path = "../middleware" }
+terraphim_settings = { path = "../settings" }
+terraphim_types = { path = "../../terraphim_types" }
+
+thiserror = "1.0.58"
+opendal = { version = "0.44.2" }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -28,9 +28,9 @@ impl<'a> TerraphimService {
         Self { config_state }
     }
 
-    /// Create a thesaurus from a haystack
-    pub async fn create_thesaurus(&self, search_query: SearchQuery) -> Result<()> {
-        Ok(create_thesaurus_from_haystack(self.config_state.clone(), search_query.clone()).await?)
+    /// Update a thesaurus from a haystack and update the knowledge graph automata URL
+    async fn update_thesaurus(&self, search_query: &SearchQuery) -> Result<()> {
+        Ok(create_thesaurus_from_haystack(self.config_state.clone(), search_query).await?)
     }
 
     /// Create article
@@ -40,7 +40,9 @@ impl<'a> TerraphimService {
     }
 
     /// Search for articles in the haystacks
-    pub async fn search_articles(&self, search_query: SearchQuery) -> Result<Vec<Article>> {
+    pub async fn search_articles(&self, search_query: &SearchQuery) -> Result<Vec<Article>> {
+        self.update_thesaurus(search_query).await?;
+
         let cached_articles =
             terraphim_middleware::search_haystacks(self.config_state.clone(), search_query.clone())
                 .await?;

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -1,0 +1,66 @@
+use persistence::Persistable;
+use terraphim_config::Config;
+use terraphim_config::ConfigState;
+use terraphim_middleware::thesaurus::create_thesaurus_from_haystack;
+use terraphim_types::{Article, IndexedDocument, SearchQuery};
+
+#[derive(thiserror::Error, Debug)]
+pub enum ServiceError {
+    #[error("An error occurred: {0}")]
+    Middleware(#[from] terraphim_middleware::Error),
+
+    #[error("OpenDal error: {0}")]
+    OpenDal(#[from] opendal::Error),
+
+    #[error("Persistence error: {0}")]
+    Persistence(#[from] persistence::Error),
+}
+
+pub type Result<T> = std::result::Result<T, ServiceError>;
+
+pub struct TerraphimService {
+    config_state: ConfigState,
+}
+
+impl<'a> TerraphimService {
+    /// Create a new TerraphimService
+    pub fn new(config_state: ConfigState) -> Self {
+        Self { config_state }
+    }
+
+    /// Create a thesaurus from a haystack
+    pub async fn create_thesaurus(&self, search_query: SearchQuery) -> Result<()> {
+        Ok(create_thesaurus_from_haystack(self.config_state.clone(), search_query.clone()).await?)
+    }
+
+    /// Create article
+    pub async fn create_article(&mut self, article: Article) -> Result<Article> {
+        self.config_state.index_article(&article).await?;
+        Ok(article)
+    }
+
+    /// Search for articles in the haystacks
+    pub async fn search_articles(&self, search_query: SearchQuery) -> Result<Vec<Article>> {
+        let cached_articles =
+            terraphim_middleware::search_haystacks(self.config_state.clone(), search_query.clone())
+                .await?;
+        let docs: Vec<IndexedDocument> = self.config_state.search_articles(search_query).await;
+        let articles = terraphim_types::merge_and_serialize(cached_articles, docs);
+
+        Ok(articles)
+    }
+
+    /// Fetch the current config
+    pub async fn fetch_config(&self) -> terraphim_config::Config {
+        let current_config = self.config_state.config.lock().await;
+        current_config.clone()
+    }
+
+    /// Update the current config
+    pub async fn update_config(&self, config_new: Config) -> Result<terraphim_config::Config> {
+        let mut config_state_lock = self.config_state.config.lock().await;
+        config_state_lock.update(config_new.clone());
+        config_state_lock.save().await?;
+        Ok(config_state_lock.clone())
+    }
+}

--- a/crates/terraphim_rolegraph/benches/throughput.rs
+++ b/crates/terraphim_rolegraph/benches/throughput.rs
@@ -48,18 +48,19 @@ fn load_sample_thesaurus() -> Thesaurus {
     thesaurus.unwrap()
 }
 
-fn bench_find_matches_ids(c: &mut Criterion) {
+fn bench_find_matching_node_idss(c: &mut Criterion) {
     let query = "I am a text with the word Life cycle concepts and bar and Trained operators and maintainers, project direction, some bingo words Paradigm Map and project planning, then again: some bingo words Paradigm Map and project planning, then repeats: Trained operators and maintainers, project direction";
     let rolegraph = block_on(get_rolegraph());
 
     let sizes = &[1, 10, 100, 1000];
     for size in sizes {
         let input = query.repeat(*size);
-        c.benchmark_group("find_matches_ids").bench_with_input(
-            BenchmarkId::new("find_matches_ids", size),
-            size,
-            |b, _| b.iter(|| rolegraph.find_matches_ids(&input)),
-        );
+        c.benchmark_group("find_matching_node_idss")
+            .bench_with_input(
+                BenchmarkId::new("find_matching_node_idss", size),
+                size,
+                |b, _| b.iter(|| rolegraph.find_matching_node_ids(&input)),
+            );
     }
 }
 
@@ -163,7 +164,7 @@ fn bench_query(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_find_matches_ids,
+    bench_find_matching_node_idss,
     bench_find_matches,
     bench_split_paragraphs,
     bench_parse_document_to_pair,

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -15,10 +15,10 @@ tauri-build = { version = "1.5.1", features = [] }
 terraphim_config = { path = "../../crates/config" }
 terraphim_middleware = { path = "../../crates/middleware" }
 terraphim_rolegraph = { path = "../../crates/terraphim_rolegraph" }
-# terraphim_server = { path = "../../terraphim_server" }
 terraphim_settings = { path = "../../crates/settings" }
 terraphim_types = { path = "../../terraphim_types" }
 persistence = { path = "../../crates/persistence" }
+service = { path = "../../crates/service" }
 
 anyhow = "1.0.81"
 log = "0.4.21"

--- a/desktop/src-tauri/src/cmd.rs
+++ b/desktop/src-tauri/src/cmd.rs
@@ -8,10 +8,10 @@ use serde::Serializer;
 use tauri::command;
 use tauri::State;
 
+use persistence::Persistable;
 use terraphim_config::{Config, ConfigState};
-use terraphim_middleware::search_haystacks;
 use terraphim_middleware::thesaurus::create_thesaurus_from_haystack;
-use terraphim_types::{merge_and_serialize, Article, IndexedDocument, SearchQuery};
+use terraphim_types::{Article, IndexedDocument, SearchQuery};
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -26,7 +26,10 @@ pub struct RequestBody {
 #[derive(Debug, thiserror::Error)]
 pub enum TerraphimTauriError {
     #[error("An error occurred: {0}")]
-    MiddlewareError(#[from] terraphim_middleware::Error),
+    Middleware(#[from] terraphim_middleware::Error),
+
+    #[error("Persistence error: {0}")]
+    Persistence(#[from] persistence::Error),
 }
 
 // Manually implement `Serialize` for our error type because some of the
@@ -42,73 +45,82 @@ impl Serialize for TerraphimTauriError {
 
 pub type Result<T> = anyhow::Result<T, TerraphimTauriError>;
 
+struct TerraphimService<'a> {
+    config_state: State<'a, ConfigState>,
+}
+
+impl<'a> TerraphimService<'a> {
+    /// Create a new TerraphimService
+    pub fn new(config_state: State<'a, ConfigState>) -> Self {
+        Self { config_state }
+    }
+
+    /// Create a thesaurus from a haystack
+    pub async fn create_thesaurus(&self, search_query: SearchQuery) -> Result<()> {
+        Ok(
+            create_thesaurus_from_haystack(self.config_state.inner().clone(), search_query.clone())
+                .await?,
+        )
+    }
+
+    /// Search for articles in the haystacks
+    pub async fn search_articles(&self, search_query: SearchQuery) -> Result<Vec<Article>> {
+        let cached_articles = terraphim_middleware::search_haystacks(
+            self.config_state.inner().clone(),
+            search_query.clone(),
+        )
+        .await?;
+        let docs: Vec<IndexedDocument> = self.config_state.search_articles(search_query).await;
+        let articles = terraphim_types::merge_and_serialize(cached_articles, docs);
+
+        Ok(articles)
+    }
+
+    /// Fetch the current config
+    pub async fn fetch_config(&self) -> Result<terraphim_config::Config> {
+        let current_config = self.config_state.config.lock().await;
+        Ok(current_config.clone())
+    }
+
+    /// Update the current config
+    pub async fn update_config(&self, config_new: Config) -> Result<terraphim_config::Config> {
+        let mut config_state_lock = self.config_state.config.lock().await;
+        config_state_lock.update(config_new.clone());
+        config_state_lock.save().await?;
+        Ok(config_state_lock.clone())
+    }
+}
+
 /// Search All TerraphimGraphs defined in a config by query param
 #[command]
 pub async fn search(
     config_state: State<'_, ConfigState>,
     search_query: SearchQuery,
 ) -> Result<Vec<Article>> {
-    println!("Search called with {:?}", search_query);
-    let current_config_state = config_state.inner().clone();
+    log::info!("Search called with {:?}", search_query);
+    let terraphim_service = TerraphimService::new(config_state);
+    terraphim_service
+        .create_thesaurus(search_query.clone())
+        .await?;
 
-    // Build thesaurus and update knowledge graph automata_url
-    log::debug!("Creating thesaurus from haystack");
-    create_thesaurus_from_haystack(config_state.inner().clone(), search_query.clone()).await?;
-    log::debug!("Thesaurus created");
-
-    let cached_articles = search_haystacks(current_config_state, search_query.clone()).await?;
-    let docs: Vec<IndexedDocument> = config_state.search_articles(search_query).await;
-    let articles = merge_and_serialize(cached_articles, docs);
-
-    Ok(articles)
+    terraphim_service.search_articles(search_query).await
 }
 
 #[command]
 pub async fn get_config(
     config_state: tauri::State<'_, ConfigState>,
 ) -> Result<terraphim_config::Config> {
-    println!("Get config called");
-    let current_config = config_state.config.lock().await;
-    println!("Get config called with {:?}", current_config);
-    Ok(current_config.clone())
+    log::info!("Get config called");
+    let terraphim_service = TerraphimService::new(config_state);
+    terraphim_service.fetch_config().await
 }
-
-use persistence::Persistable;
 
 #[command]
 pub async fn update_config(
     config_state: tauri::State<'_, ConfigState>,
     config_new: Config,
 ) -> Result<terraphim_config::Config> {
-    println!("Update config called with {:?}", config_new);
-    let mut config_state = config_state.config.lock().await;
-    config_state.update(config_new.clone());
-    // FIXME: add tauri error TerraphimTauriError and use context
-    let _ = config_state.save().await;
-    Ok(config_state.clone())
+    log::info!("Update config called with {:?}", config_new);
+    let terraphim_service = TerraphimService::new(config_state);
+    terraphim_service.update_config(config_new).await
 }
-// pub struct Port(u16);
-
-// /// A command to get the unused port instead of 3000.
-// #[tauri::command]
-// pub fn _get_port(port: tauri::State<Port>) -> Result<String> {
-//     Ok(format!("{}", port.0))
-// }
-
-// use std::net::SocketAddr;
-// use terraphim_server::axum_server;
-
-// /// Start the server, currently not in use, but will be important for OAuth etc in the future.
-// #[tauri::command]
-// async fn _start_server() -> Result<()> {
-//     let port = portpicker::pick_unused_port().expect("failed to find unused port");
-//     let addr = SocketAddr::from(([127, 0, 0, 1], port));
-//     let mut config = Config::new();
-//     let config_state = ConfigState::new(&mut config).await.unwrap();
-//     tauri::async_runtime::spawn(async move {
-//         if let Err(e) = axum_server(addr, config_state).await {
-//             println!("Failed to start axum server: {e:?}");
-//         }
-//     });
-//     Ok(())
-// }

--- a/desktop/src-tauri/src/cmd.rs
+++ b/desktop/src-tauri/src/cmd.rs
@@ -5,13 +5,12 @@
 use serde::Deserialize;
 use serde::Serialize;
 use serde::Serializer;
+use service::TerraphimService;
 use tauri::command;
 use tauri::State;
 
-use persistence::Persistable;
 use terraphim_config::{Config, ConfigState};
-use terraphim_middleware::thesaurus::create_thesaurus_from_haystack;
-use terraphim_types::{Article, IndexedDocument, SearchQuery};
+use terraphim_types::{Article, SearchQuery};
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -30,6 +29,9 @@ pub enum TerraphimTauriError {
 
     #[error("Persistence error: {0}")]
     Persistence(#[from] persistence::Error),
+
+    #[error("Service error: {0}")]
+    Service(#[from] service::ServiceError),
 }
 
 // Manually implement `Serialize` for our error type because some of the
@@ -45,52 +47,6 @@ impl Serialize for TerraphimTauriError {
 
 pub type Result<T> = anyhow::Result<T, TerraphimTauriError>;
 
-struct TerraphimService<'a> {
-    config_state: State<'a, ConfigState>,
-}
-
-impl<'a> TerraphimService<'a> {
-    /// Create a new TerraphimService
-    pub fn new(config_state: State<'a, ConfigState>) -> Self {
-        Self { config_state }
-    }
-
-    /// Create a thesaurus from a haystack
-    pub async fn create_thesaurus(&self, search_query: SearchQuery) -> Result<()> {
-        Ok(
-            create_thesaurus_from_haystack(self.config_state.inner().clone(), search_query.clone())
-                .await?,
-        )
-    }
-
-    /// Search for articles in the haystacks
-    pub async fn search_articles(&self, search_query: SearchQuery) -> Result<Vec<Article>> {
-        let cached_articles = terraphim_middleware::search_haystacks(
-            self.config_state.inner().clone(),
-            search_query.clone(),
-        )
-        .await?;
-        let docs: Vec<IndexedDocument> = self.config_state.search_articles(search_query).await;
-        let articles = terraphim_types::merge_and_serialize(cached_articles, docs);
-
-        Ok(articles)
-    }
-
-    /// Fetch the current config
-    pub async fn fetch_config(&self) -> Result<terraphim_config::Config> {
-        let current_config = self.config_state.config.lock().await;
-        Ok(current_config.clone())
-    }
-
-    /// Update the current config
-    pub async fn update_config(&self, config_new: Config) -> Result<terraphim_config::Config> {
-        let mut config_state_lock = self.config_state.config.lock().await;
-        config_state_lock.update(config_new.clone());
-        config_state_lock.save().await?;
-        Ok(config_state_lock.clone())
-    }
-}
-
 /// Search All TerraphimGraphs defined in a config by query param
 #[command]
 pub async fn search(
@@ -98,12 +54,8 @@ pub async fn search(
     search_query: SearchQuery,
 ) -> Result<Vec<Article>> {
     log::info!("Search called with {:?}", search_query);
-    let terraphim_service = TerraphimService::new(config_state);
-    terraphim_service
-        .create_thesaurus(search_query.clone())
-        .await?;
-
-    terraphim_service.search_articles(search_query).await
+    let terraphim_service = TerraphimService::new(config_state.inner().clone());
+    Ok(terraphim_service.search_articles(&search_query).await?)
 }
 
 #[command]
@@ -111,8 +63,8 @@ pub async fn get_config(
     config_state: tauri::State<'_, ConfigState>,
 ) -> Result<terraphim_config::Config> {
     log::info!("Get config called");
-    let terraphim_service = TerraphimService::new(config_state);
-    terraphim_service.fetch_config().await
+    let terraphim_service = TerraphimService::new(config_state.inner().clone());
+    Ok(terraphim_service.fetch_config().await)
 }
 
 #[command]
@@ -121,6 +73,6 @@ pub async fn update_config(
     config_new: Config,
 ) -> Result<terraphim_config::Config> {
     log::info!("Update config called with {:?}", config_new);
-    let terraphim_service = TerraphimService::new(config_state);
-    terraphim_service.update_config(config_new).await
+    let terraphim_service = TerraphimService::new(config_state.inner().clone());
+    Ok(terraphim_service.update_config(config_new).await?)
 }

--- a/desktop/src/lib/Search/Search.svelte
+++ b/desktop/src/lib/Search/Search.svelte
@@ -1,57 +1,59 @@
 <script lang="ts">
-  import { Field, Input } from 'svelma';
-  import { invoke } from '@tauri-apps/api/tauri';
-  import logo from '/public/assets/terraphim_gray.png';
-  import { role, is_tauri, input, serverUrl} from '../stores';
-  import type { SearchResult } from './SearchResult';
-  import ResultItem from './ResultItem.svelte';
-  import { CONFIG } from '../../config';
-    import { subscribe } from 'svelte/internal';
+  import { Field, Input } from "svelma";
+  import { invoke } from "@tauri-apps/api/tauri";
+  import logo from "/public/assets/terraphim_gray.png";
+  import { role, is_tauri, input, serverUrl } from "../stores";
+  import type { SearchResult } from "./SearchResult";
+  import ResultItem from "./ResultItem.svelte";
+  import { CONFIG } from "../../config";
+  import { subscribe } from "svelte/internal";
   let result: SearchResult[] = [];
-  
+
   let currentSearchUrl;
   async function handleClick() {
     if ($is_tauri) {
       console.log("Tauri config");
       console.log($input);
-      await invoke('search', { searchQuery: {
-        search_term: $input,
-        skip: 0,
-        limit: 10,
-        role: $role,
-    }})
-        .then(data => {
-          console.log(data);
-          result = data;
-        })
-        .catch(e => console.error(e));
-    } else {
-      console.log($input);
-      console.log("Role config");
-      console.log($role);
-      console.log('The current value is: ',$serverUrl);
-      let json_body= JSON.stringify({
+      await invoke("search", {
+        searchQuery: {
           search_term: $input,
           skip: 0,
           limit: 10,
           role: $role,
-        });
-      console.log('The current value is: ',json_body);
+        },
+      })
+        .then((data) => {
+          console.log(data);
+          result = data;
+        })
+        .catch((e) => console.error(e));
+    } else {
+      console.log($input);
+      console.log("Role config");
+      console.log($role);
+      console.log("The current value is: ", $serverUrl);
+      let json_body = JSON.stringify({
+        search_term: $input,
+        skip: 0,
+        limit: 10,
+        role: $role,
+      });
+      console.log("The current value is: ", json_body);
 
-  const response = await fetch($serverUrl, {
-        method: 'POST',
+      console.log("Server URL: ", $serverUrl);
+      const response = await fetch($serverUrl, {
+        method: "POST",
         headers: {
-          accept: 'application/json',
-          'Content-Type': 'application/json',
+          accept: "application/json",
+          "Content-Type": "application/json",
         },
         body: json_body,
       });
       const data = await response.json();
       console.log(data);
-      result=data;
+      result = data;
+    }
   }
-  }
-
 </script>
 
 <Field>
@@ -64,7 +66,7 @@
     autofocus
     on:click={handleClick}
     on:submit={handleClick}
-    on:keyup={e => e.key === 'Enter' && handleClick()}
+    on:keyup={(e) => e.key === "Enter" && handleClick()}
   />
 </Field>
 {#if result !== null && result.length !== 0}

--- a/terraphim_server/Cargo.toml
+++ b/terraphim_server/Cargo.toml
@@ -11,6 +11,7 @@ terraphim_rolegraph = { path = "../crates/terraphim_rolegraph" }
 terraphim_settings = { path = "../crates/settings" }
 terraphim_types = { path = "../terraphim_types" }
 terraphim_automata = { path = "../crates/terraphim_automata" }
+service = { path = "../crates/service" }
 
 anyhow = "1.0.40"
 axum = { version = "0.6.2", features = ["macros"] }

--- a/terraphim_server/src/api.rs
+++ b/terraphim_server/src/api.rs
@@ -67,12 +67,22 @@ pub(crate) async fn search_articles_post(
     State(config_state): State<ConfigState>,
     search_query: Json<SearchQuery>,
 ) -> Result<Json<Vec<Article>>> {
-    println!("POST Searching articles with query: {search_query:?}");
     log::info!("POST Searching articles with query: {search_query:?}");
 
     let terraphim_service = TerraphimService::new(config_state);
     let articles = terraphim_service.search_articles(&search_query.0).await?;
-    log::trace!("Final articles: {articles:?}");
+
+    // Check if log level is debug:
+    if log::log_enabled!(log::Level::Debug) {
+        log::debug!("Articles found:");
+        for article in &articles {
+            log::debug!(
+                "{} -> {}",
+                article.id.as_ref().unwrap(),
+                article.rank.unwrap()
+            );
+        }
+    }
 
     Ok(Json(articles))
 }

--- a/terraphim_server/src/api.rs
+++ b/terraphim_server/src/api.rs
@@ -56,11 +56,7 @@ pub(crate) async fn search_articles(
 ) -> Result<Json<Vec<Article>>> {
     log::info!("Search called with {:?}", search_query);
     let terraphim_service = TerraphimService::new(config_state);
-    terraphim_service
-        .create_thesaurus(search_query.0.clone())
-        .await?;
-
-    let articles = terraphim_service.search_articles(search_query.0).await?;
+    let articles = terraphim_service.search_articles(&search_query.0).await?;
 
     Ok(Json(articles))
 }
@@ -75,15 +71,7 @@ pub(crate) async fn search_articles_post(
     log::debug!("POST Searching articles with query: {search_query:?}");
 
     let terraphim_service = TerraphimService::new(config_state);
-
-    // Build thesaurus and update knowledge graph automata_url
-    log::debug!("Creating thesaurus from haystack");
-    terraphim_service
-        .create_thesaurus(search_query.0.clone())
-        .await?;
-    log::debug!("Thesaurus created");
-
-    let articles = terraphim_service.search_articles(search_query.0).await?;
+    let articles = terraphim_service.search_articles(&search_query.0).await?;
     log::trace!("Final articles: {articles:?}");
 
     Ok(Json(articles))

--- a/terraphim_server/src/api.rs
+++ b/terraphim_server/src/api.rs
@@ -18,10 +18,10 @@ use crate::error::Result;
 
 pub type SearchResultsStream = Sender<IndexedDocument>;
 
-/// health check endpoint
 pub(crate) async fn health_axum() -> impl IntoResponse {
     (StatusCode::OK, "OK")
 }
+
 /// Creates index of the article for each rolegraph
 pub(crate) async fn create_article(
     State(config): State<ConfigState>,
@@ -42,13 +42,12 @@ pub(crate) async fn _list_articles(
     State(rolegraph): State<Arc<Mutex<RoleGraph>>>,
 ) -> impl IntoResponse {
     let rolegraph = rolegraph.lock().await.clone();
-    println!("{rolegraph:?}");
+    log::debug!("{rolegraph:?}");
 
     (StatusCode::OK, Json("Ok"))
 }
 
 /// Search All TerraphimGraphs defined in a config by query params.
-#[axum::debug_handler]
 pub(crate) async fn search_articles(
     Extension(_tx): Extension<SearchResultsStream>,
     State(config_state): State<ConfigState>,
@@ -68,7 +67,8 @@ pub(crate) async fn search_articles_post(
     State(config_state): State<ConfigState>,
     search_query: Json<SearchQuery>,
 ) -> Result<Json<Vec<Article>>> {
-    log::debug!("POST Searching articles with query: {search_query:?}");
+    println!("POST Searching articles with query: {search_query:?}");
+    log::info!("POST Searching articles with query: {search_query:?}");
 
     let terraphim_service = TerraphimService::new(config_state);
     let articles = terraphim_service.search_articles(&search_query.0).await?;

--- a/terraphim_server/src/lib.rs
+++ b/terraphim_server/src/lib.rs
@@ -25,6 +25,7 @@ static INDEX_HTML: &str = "index.html";
 struct Assets;
 
 pub async fn axum_server(server_hostname: SocketAddr, config_state: ConfigState) -> Result<()> {
+    log::info!("Starting axum server");
     // let assets = axum_embed::ServeEmbed::<Assets>::with_parameters(Some("index.html".to_owned()),axum_embed::FallbackBehavior::Ok, Some("index.html".to_owned()));
     let (tx, _rx) = channel::<IndexedDocument>(10);
 

--- a/terraphim_types/src/lib.rs
+++ b/terraphim_types/src/lib.rs
@@ -384,7 +384,7 @@ pub struct IndexedDocument {
     /// UUID of the indexed document, matching external storage id
     pub id: String,
     /// Matched to edges
-    pub matched_to: Vec<Edge>,
+    pub matched_edges: Vec<Edge>,
     /// Graph rank (the sum of node rank, edge rank)
     pub rank: u64,
     /// tags, which are nodes turned into concepts for human readability


### PR DESCRIPTION
This pull request moves the shared logic to the `terraphim_service` crate. It also updates the `terraphim_service` interface, fixes some frontend issues, and performs code cleanup. Additionally, it fixes the ordering of search results (search is now stable and based on ranking and article id) and improves logging.