### PR TITLE
WIP: GMail support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "ureq",
- "url",
+ "url 2.5.0",
  "urlencoding",
 ]
 
@@ -235,6 +235,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5509d663b2c00ee421bda8d6a24d6c42e15970957de1701b8df9f6fbe5707df1"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5d317212c2a78d86ba6622e969413c38847b62f48111f8b763af3dac2f9840"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +280,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -280,13 +307,13 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
  "itoa 1.0.10",
  "matchit",
  "memchr",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -407,6 +434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +464,29 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.55",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.55",
+ "which",
 ]
 
 [[package]]
@@ -802,6 +858,15 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cocoa"
@@ -1523,7 +1588,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -1535,6 +1600,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -1898,6 +1969,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-apis-common"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78672323eaeeb181cadd4d07333f1bcc8c2840a55b58afa8ab052664cd4a54ad"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "itertools 0.10.5",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_with 2.3.3",
+ "tokio",
+ "tower-service",
+ "url 1.7.2",
+ "yup-oauth2",
+]
+
+[[package]]
+name = "google-gmail1"
+version = "5.0.4+20240226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e8412a6ac2b47c9103331fd183e2c4b7fd30bca7512ff625206c7c88f36210"
+dependencies = [
+ "anyhow",
+ "google-apis-common",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
+ "itertools 0.10.5",
+ "mime",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-service",
+ "url 1.7.2",
+]
+
+[[package]]
 name = "gtk"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2197,6 +2309,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2208,9 +2321,30 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
+ "log",
  "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908bb38696d7a037a01ebcc68a00634112ac2bbf8ca74e30a2c3d2f4f021302b"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "log",
+ "rustls 0.23.5",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -2233,13 +2367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2280,6 +2418,17 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -2389,6 +2538,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2604,7 +2762,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "bzip2-sys",
  "cc",
  "glob",
@@ -2817,6 +2975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,6 +3154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,7 +3232,7 @@ dependencies = [
  "log",
  "md-5",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "prost",
  "quick-xml 0.30.0",
  "redis",
@@ -3220,6 +3393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "path-matchers"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,6 +3447,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -3831,19 +4016,19 @@ dependencies = [
  "futures-util",
  "itoa 1.0.10",
  "log",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rand 0.8.5",
  "rustls 0.21.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "ryu",
  "sha1_smol",
  "socket2 0.4.10",
  "tokio",
  "tokio-retry",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -3938,7 +4123,7 @@ dependencies = [
  "jsonwebtoken",
  "log",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "quick-xml 0.31.0",
  "rand 0.8.5",
  "reqwest",
@@ -3965,7 +4150,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3973,11 +4158,11 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustls 0.21.10",
- "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3985,10 +4170,10 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
- "url",
+ "url 2.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
@@ -4167,13 +4352,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -4185,6 +4398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4209,6 +4432,7 @@ version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -4285,6 +4509,12 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -4424,6 +4654,22 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros 2.3.3",
+ "time",
+]
+
+[[package]]
+name = "serde_with"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
@@ -4436,8 +4682,20 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 3.7.0",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling 0.20.8",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4974,7 +5232,7 @@ dependencies = [
  "ignore",
  "objc",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "rand 0.8.5",
  "raw-window-handle",
  "semver",
@@ -4991,7 +5249,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "url",
+ "url 2.5.0",
  "uuid",
  "webkit2gtk",
  "webview2-com",
@@ -5071,7 +5329,7 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "thiserror",
- "url",
+ "url 2.5.0",
  "uuid",
  "webview2-com",
  "windows 0.39.0",
@@ -5085,7 +5343,7 @@ checksum = "067c56fc153b3caf406d7cd6de4486c80d1d66c0f414f39e94cb2f5543f6445f"
 dependencies = [
  "cocoa",
  "gtk",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "rand 0.8.5",
  "raw-window-handle",
  "tauri-runtime",
@@ -5120,9 +5378,9 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.7.0",
  "thiserror",
- "url",
+ "url 2.5.0",
  "walkdir",
  "windows-version",
 ]
@@ -5214,7 +5472,7 @@ dependencies = [
  "terraphim_types",
  "thiserror",
  "tokio",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5241,7 +5499,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5250,6 +5508,9 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.11",
  "cached",
+ "google-gmail1",
+ "hyper 1.3.1",
+ "hyper-rustls 0.27.1",
  "log",
  "persistence",
  "serde",
@@ -5262,7 +5523,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "ulid",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5285,7 +5546,7 @@ dependencies = [
  "tokio",
  "ulid",
  "unicode-segmentation",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5322,7 +5583,7 @@ dependencies = [
  "tower",
  "tower-http",
  "ulid",
- "url",
+ "url 2.5.0",
  "walkdir",
 ]
 
@@ -5432,7 +5693,9 @@ checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa 1.0.10",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5547,6 +5810,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.5",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5676,7 +5950,7 @@ dependencies = [
  "httpdate",
  "mime",
  "mime_guess",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -5877,8 +6151,19 @@ dependencies = [
  "rustls 0.22.3",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
- "url",
+ "url 2.5.0",
  "webpki-roots 0.26.1",
+]
+
+[[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
 ]
 
 [[package]]
@@ -5888,8 +6173,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
- "percent-encoding",
+ "idna 0.5.0",
+ "percent-encoding 2.3.1",
  "serde",
 ]
 
@@ -6199,6 +6484,18 @@ dependencies = [
  "windows 0.39.0",
  "windows-bindgen",
  "windows-metadata",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -6535,7 +6832,7 @@ dependencies = [
  "soup2",
  "tao",
  "thiserror",
- "url",
+ "url 2.5.0",
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
@@ -6573,6 +6870,33 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "yup-oauth2"
+version = "8.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b61da40aeb0907a65f7fb5c1de83c5a224d6a9ebb83bf918588a2bb744d636b8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
+ "itertools 0.12.1",
+ "log",
+ "percent-encoding 2.3.1",
+ "rustls 0.22.3",
+ "rustls-pemfile 1.0.4",
+ "seahash",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tower-service",
+ "url 2.5.0",
 ]
 
 [[package]]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -78,6 +78,8 @@ pub struct Role {
 pub enum ServiceType {
     /// Use ripgrep as the indexing service
     Ripgrep,
+    /// Use gmail as the indexing service
+    Gmail,
 }
 
 /// A haystack is a collection of documents that can be indexed and searched

--- a/crates/middleware/Cargo.toml
+++ b/crates/middleware/Cargo.toml
@@ -20,3 +20,6 @@ tokio = { version = "1.15.0", features = ["full"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 ulid = { version = "1.0.0", features = ["serde", "uuid"] }
 url = "2.5.0"
+google-gmail1 = "5.0.4"
+hyper = "1.3.1"
+hyper-rustls = "0.27.1"

--- a/crates/middleware/src/indexer/gmail.rs
+++ b/crates/middleware/src/indexer/gmail.rs
@@ -1,0 +1,88 @@
+use std::path::Path;
+use terraphim_types::{Document, Index};
+extern crate google_gmail1 as gmail1;
+use super::{hash_as_string, IndexMiddleware};
+use crate::{Error, Result};
+use gmail1::api::Message;
+use gmail1::{hyper, hyper_rustls, oauth2, Gmail};
+use std::default::Default;
+
+/// Middleware that uses Gmail API to index Email haystack.
+#[derive(Default)]
+pub struct GmailIndexer {
+    // // E-Mail address of the user
+    // user_id: String,
+}
+
+impl IndexMiddleware for GmailIndexer {
+    /// Index the email haystack using Gmail API and return an index of documents
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the middleware fails to index the haystack
+    async fn index(&self, needle: &str, haystack: &Path) -> Result<Index> {
+        log::debug!("Indexing email haystack using Gmail API");
+        // Get an ApplicationSecret instance by some means. It contains the `client_id` and
+        // `client_secret`, among other things.
+        let secret: oauth2::ApplicationSecret = Default::default();
+        // Instantiate the authenticator. It will choose a suitable authentication flow for you,
+        // unless you replace `None` with the desired Flow.
+        // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about
+        // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+        // retrieve them from storage.
+        let auth = oauth2::InstalledFlowAuthenticator::builder(
+            secret,
+            oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+        )
+        .build()
+        .await?;
+
+        log::debug!("Authenticating with Gmail API");
+
+        let hub = Gmail::new(
+            hyper::Client::builder().build(
+                hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_native_roots()
+                    .https_or_http()
+                    .enable_http1()
+                    .build(),
+            ),
+            auth,
+        );
+
+        log::debug!("Fetching messages from Gmail API");
+
+        let result = hub
+            .users()
+            // .messages_list(user_id)
+            .messages_list("me")
+            .q(needle)
+            .max_results(55)
+            .include_spam_trash(false)
+            .doit()
+            .await
+            .map_err(|e| {
+                Error::Indexation(format!("Failed to index the email haystack: {:?}", e))
+            })?;
+
+        log::debug!("Retrieved the following messages: {:?}", result.1);
+
+        let mut index: Index = Index::default();
+
+        let Some(messages) = result.1.messages else {
+            return Ok(index);
+        };
+
+        for message in messages {
+            let mut document: Document = Document::default();
+            document.id = hash_as_string(&message.id);
+            document.title = message.snippet.clone().unwrap_or_default();
+            document.url = message.id.clone().unwrap_or_default();
+            index.insert(document.id.to_string(), document.clone());
+        }
+
+        log::debug!("Indexed the following documents: {:?}", index);
+
+        Ok(index)
+    }
+}

--- a/crates/middleware/src/indexer/mod.rs
+++ b/crates/middleware/src/indexer/mod.rs
@@ -6,8 +6,10 @@ use terraphim_types::{Index, SearchQuery};
 
 use crate::{Error, Result};
 
+mod gmail;
 mod ripgrep;
 
+pub use gmail::GmailIndexer;
 pub use ripgrep::RipgrepIndexer;
 
 fn hash_as_string<T: Hash>(t: &T) -> String {
@@ -45,7 +47,6 @@ pub async fn search_haystacks(
     let search_query_role = search_query.role.unwrap_or(config.default_role);
     let needle = &search_query.search_term;
 
-    let ripgrep = RipgrepIndexer::default();
     let mut full_index = Index::new();
 
     let role = config
@@ -60,7 +61,13 @@ pub async fn search_haystacks(
             ServiceType::Ripgrep => {
                 // Search through documents using ripgrep
                 // This indexes the haystack using the ripgrep middleware
+                let ripgrep = RipgrepIndexer::default();
                 ripgrep.index(needle, &haystack.path).await?
+            }
+            ServiceType::Gmail => {
+                // Search through Gmail using the Gmail index
+                let gmail = GmailIndexer::default();
+                gmail.index(needle, &haystack.path).await?
             }
         };
 


### PR DESCRIPTION
This uses [`google-gmail1`](https://crates.io/crates/google-gmail1) for interfacing with GMail to search through E-Mail.

So far, I've only added a stub to the middleware.
It's a prototype and by far not done yet.


# TODO

- [ ] Clarify GMail authentication. See docs [here](https://developers.google.com/gmail/api/guides) and [here](https://developers.google.com/workspace/guides/get-started) 
- [ ] Add GMail support to `Config` option
- [ ] Testing