### PR TITLE
Create marketing materials for multiple platforms

### DIFF
--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -1,0 +1,277 @@
+# Blog Post: Building Privacy-First AI Tools with X Integration
+
+## Title Options
+
+1. "Why We're Building X/Twitter Integration for Our Privacy-First AI Assistant"
+2. "Terraphim AI: Unifying Your Scattered Knowledge with Local-First Architecture"
+3. "From Fragmented Knowledge to Unified Search: Building AI Tools That Respect Your Privacy"
+4. "The Case for Local-First AI Assistants with Social Media Integration"
+
+---
+
+## Full Blog Post
+
+# Building Privacy-First AI Tools with X Integration
+
+**Subtitle:** How Terraphim AI is solving knowledge fragmentation while keeping your data local
+
+---
+
+## The Knowledge Fragmentation Problem
+
+If you're a knowledge worker, you're probably familiar with this scenario:
+
+You remember reading about a specific technical solution - maybe it was handling async cancellation in Rust, or a particular database optimization pattern. You know you saw it somewhere. But where?
+
+Was it in your Obsidian notes? A Confluence document from your team? A StackOverflow answer you bookmarked? A GitHub issue you commented on? Or that brilliant Twitter thread someone shared six months ago?
+
+Studies show knowledge workers spend approximately 20% of their time just searching for information - that's one full day per week lost to the fragmentation of our digital knowledge landscape.
+
+And it's getting worse.
+
+---
+
+## The Privacy Dilemma
+
+Modern AI assistants promise to solve this problem. Upload your documents, connect your tools, let the AI search everything for you.
+
+But here's the catch: you're sending your private notes, proprietary code, confidential client information, and personal research to external servers. Your data becomes training material for models you don't control.
+
+For many of us, this trade-off isn't acceptable.
+
+---
+
+## Introducing Terraphim AI
+
+Terraphim AI is our answer to knowledge fragmentation - a privacy-first AI assistant that runs entirely locally on your hardware.
+
+**No cloud uploads. No external servers. Your data stays yours.**
+
+### How It Works
+
+Rather than using generic embeddings that require external processing, Terraphim uses a **knowledge graph with semantic thesaurus**. Here's what that means:
+
+1. **Concept Mapping**: You define relationships between concepts in your domain. "Async cancellation" relates to "task abort", "cooperative scheduling", "graceful shutdown".
+
+2. **Aho-Corasick Automata**: We build fast text-matching automata from your thesaurus. O(n) search complexity regardless of vocabulary size.
+
+3. **Multi-Source Indexing**: Your local files, Obsidian notes, Confluence docs, GitHub repos - all indexed into the same knowledge graph.
+
+4. **Semantic Search**: When you search "async cancellation", you find documents mentioning "task abort patterns" even if they never use the exact phrase.
+
+---
+
+## Current Integrations
+
+Terraphim already connects to:
+
+- **Local Filesystem**: Markdown files, code, any text
+- **Personal Knowledge Bases**: Obsidian, Logseq, Notion
+- **Team Tools**: Confluence, Jira, SharePoint
+- **Developer Resources**: StackOverflow, GitHub, Reddit
+- **Email**: JMAP protocol support
+- **AI Tools**: MCP (Model Context Protocol) for AI integration
+
+All searches return unified results ranked by configurable relevance functions (BM25, BM25F, BM25Plus, or graph-based scoring).
+
+---
+
+## Why X/Twitter Integration?
+
+Here's what's missing from our current setup: **social knowledge discovery**.
+
+X (formerly Twitter) has become a critical source of technical knowledge:
+
+- Real-time bug solutions shared in threads
+- Architecture debates with industry experts
+- Breaking changes announced before documentation updates
+- Domain-specific insights from practitioners
+
+These discussions contain valuable knowledge that often doesn't exist anywhere else. When someone solves an obscure issue and shares it in a thread, that knowledge lives only on X.
+
+**The problem**: X's native search is limited, and bookmarked threads become forgotten.
+
+**Our solution**: Index your X activity into your local knowledge graph.
+
+---
+
+## What X Integration Will Enable
+
+We're building X API integration to:
+
+### 1. Index Your Bookmarks
+Every technical thread you bookmark gets indexed locally. Concepts extracted, relationships mapped, searchable alongside your other knowledge.
+
+### 2. Track Relevant Accounts
+Follow specific technical accounts and automatically index their discussions into your domain-specific knowledge graph.
+
+### 3. Enrich Your Thesaurus
+Extract new concept relationships from X discussions. If experts are discussing "zero-cost abstractions" in the context of "Rust performance", your thesaurus learns this relationship.
+
+### 4. Reconstruct Thread Context
+Threads are conversations. We preserve the full context, not just individual tweets, so semantic search understands the complete discussion.
+
+### 5. Connect Social and Private Knowledge
+When you search "database connection pooling", you get:
+- Your local notes
+- Team documentation
+- StackOverflow answers
+- **AND** that Twitter thread from @databases_expert explaining the specific gotcha you hit
+
+**All from one search. All stored locally.**
+
+---
+
+## Technical Architecture
+
+For the technically curious, here's how Terraphim is built:
+
+### Rust Backend
+29 library crates in a Cargo workspace:
+- `terraphim_service`: Core service layer
+- `terraphim_automata`: Text matching and autocomplete
+- `terraphim_rolegraph`: Knowledge graph implementation
+- `terraphim_middleware`: Search orchestration
+- `terraphim_persistence`: Storage backends (memory, SQLite, ReDB)
+
+### Async Throughout
+Full tokio integration with:
+- Bounded channels for backpressure
+- Concurrent API calls with `tokio::join!`
+- Structured concurrency with proper cancellation
+
+### Multiple Interfaces
+- **Desktop App**: Svelte + Tauri
+- **Terminal UI**: Interactive REPL with semantic search
+- **Web API**: REST endpoints for custom integrations
+- **MCP Server**: Model Context Protocol for AI tool integration
+
+### Local LLM Support
+- Ollama integration for completely local AI
+- OpenRouter for optional cloud models
+- Document summarization
+- Context-aware chat
+
+### Security-First Execution
+Firecracker microVM integration with sub-2 second boot times for sandboxed command execution.
+
+---
+
+## The Local-First Philosophy
+
+Terraphim embodies local-first software principles:
+
+1. **Privacy by Architecture**: Your data physically cannot leave your machine because the processing happens locally.
+
+2. **Ownership**: Your knowledge graph is yours. Export it, back it up, modify it directly.
+
+3. **Determinism**: Same query, same results. No model drift, no A/B testing on your searches.
+
+4. **Offline Capability**: Network down? Your local knowledge is still searchable.
+
+5. **No Vendor Lock-in**: Open source under Apache 2.0. Fork it, self-host it, customize it.
+
+---
+
+## Getting Started
+
+Try Terraphim today:
+
+```bash
+# One-liner installation
+curl -fsSL https://raw.githubusercontent.com/terraphim/terraphim-ai/main/release/v0.2.3/install.sh | bash
+
+# Or via Docker
+docker run ghcr.io/terraphim/terraphim-server:latest
+
+# Or Homebrew (macOS/Linux)
+brew install terraphim/terraphim-ai/terraphim-ai
+
+# Build from source
+git clone https://github.com/terraphim/terraphim-ai
+cd terraphim-ai
+cargo build --release
+```
+
+---
+
+## The Road Ahead
+
+X/Twitter integration is our next major milestone. Here's what we're planning:
+
+**Phase 1: Core X Indexing**
+- OAuth 2.0 authentication
+- Bookmark synchronization
+- Basic thread indexing
+- Rate limit handling
+
+**Phase 2: Semantic Enrichment**
+- Concept extraction from tweets
+- Thesaurus expansion
+- Thread context reconstruction
+- Sentiment and relevance scoring
+
+**Phase 3: Advanced Features**
+- List-based filtering
+- Account-specific tracking
+- Temporal search (tweets from specific periods)
+- Cross-reference with other sources
+
+---
+
+## Why We Need Your Support
+
+Building X API integration right requires:
+
+1. **X API Access**: We're applying for appropriate API tier access
+2. **Community Feedback**: What features matter most to you?
+3. **Testing**: Diverse use cases help us build robust integration
+4. **Contributions**: Open source thrives on community involvement
+
+### How to Help
+
+- **Star our GitHub repo**: https://github.com/terraphim/terraphim-ai
+- **Join our Discord**: https://discord.gg/VPJXB6BGuY
+- **Try Terraphim**: Install it, use it, report issues
+- **Share this post**: Help us reach developers who value privacy
+- **Contribute code**: PRs welcome under Apache 2.0
+
+---
+
+## Conclusion
+
+The future of AI assistants shouldn't require surrendering your privacy. Your private notes, proprietary code, confidential documents, and personal insights deserve protection even as you leverage AI capabilities.
+
+Terraphim AI proves that privacy-first doesn't mean feature-poor. You can have:
+- Semantic search across fragmented knowledge
+- Local LLM integration
+- Multi-source indexing
+- Knowledge graph intelligence
+
+All while keeping your data completely local.
+
+X/Twitter integration extends this philosophy to social knowledge discovery. Your bookmarked technical threads become part of your personal knowledge graph, searchable alongside everything else, stored only on your machine.
+
+**Privacy-first. Local-first. Your knowledge, your control.**
+
+---
+
+## Links
+
+- **GitHub**: https://github.com/terraphim/terraphim-ai
+- **Discord**: https://discord.gg/VPJXB6BGuY
+- **Documentation**: https://terraphim.discourse.group
+- **License**: Apache 2.0
+
+---
+
+## Call to Action Variants
+
+**For Developer Audiences:**
+"Fork the repo, build X integration with us. The knowledge graph architecture is designed for extensibility. Let's solve knowledge fragmentation together."
+
+**For Privacy-Conscious Audiences:**
+"Try Terraphim today. Your data stays yours. No cloud uploads, no external processing, no compromises. Install it in one command and experience AI assistance without surveillance."
+
+**For Startup/Product Audiences:**
+"We're proving that privacy-first and feature-rich aren't mutually exclusive. Star our repo, share with your team, help us build the future of AI assistants that respect user autonomy."

--- a/marketing/hackernews-submission.md
+++ b/marketing/hackernews-submission.md
@@ -1,0 +1,146 @@
+# Hacker News Submission
+
+## Primary Submission (Show HN)
+
+**Title:** Show HN: Terraphim AI - Privacy-first local knowledge search with semantic graphs
+
+**URL:** https://github.com/terraphim/terraphim-ai
+
+**Text (for "Ask HN" variant):**
+
+I built Terraphim AI to solve a problem I kept hitting: knowledge fragmentation.
+
+My notes are in Obsidian. Team docs in Confluence. Code discussions in GitHub. Technical insights scattered across Twitter threads I bookmarked. When I need to find something, I'm searching 5+ tools hoping I remember where I saw it.
+
+Terraphim unifies search across all these sources while keeping everything local. No uploading to cloud AI services. No privacy trade-offs.
+
+**Technical approach:**
+
+- Knowledge graph with semantic thesaurus (not just keyword search)
+- Aho-Corasick automata for fast text matching
+- Multiple scoring algorithms (BM25, BM25F, TerraphimGraph)
+- Role-based personalization (different knowledge contexts)
+- Rust backend with async/await throughout
+- Ollama integration for local LLM
+- WASM support for browser autocomplete
+
+**Current integrations:** Local filesystem, Obsidian, Logseq, Notion, Confluence, Jira, StackOverflow, GitHub, Reddit, Email (JMAP)
+
+**Building next:** X/Twitter API integration to index bookmarked technical threads into the local knowledge graph.
+
+The privacy angle isn't just philosophical - it's practical. When you're searching proprietary code, client documents, or private research notes, uploading to external servers isn't acceptable.
+
+Would love feedback on:
+- The knowledge graph approach vs traditional vector embeddings
+- Scoring function trade-offs (BM25 family vs graph-based)
+- Interest in specific integrations (Slack? Discord? Linear?)
+
+Apache 2.0. Written in Rust. Contributions welcome.
+
+---
+
+## Alternative Titles (A/B Testing)
+
+1. "Show HN: Privacy-first AI assistant that searches local files, Notion, Obsidian without cloud upload"
+
+2. "Show HN: Local knowledge graph search across 10+ sources - Rust, Ollama, no cloud required"
+
+3. "Show HN: Terraphim - Semantic search across your fragmented knowledge (local-first)"
+
+4. "Show HN: Building a local AI assistant with knowledge graphs instead of vector embeddings"
+
+5. "Show HN: Open-source alternative to cloud AI assistants - runs 100% locally with semantic search"
+
+---
+
+## Comment Response Templates
+
+### For "How is this different from X?" questions:
+
+**vs. Perplexity/ChatGPT:**
+The core difference is privacy architecture. Those services require sending your queries and documents to their servers. Terraphim runs entirely locally - your private notes, proprietary code, and confidential docs never leave your machine.
+
+Beyond privacy, we use knowledge graphs with semantic thesaurus instead of just vector embeddings. This means:
+- Explicit concept relationships (not just similarity)
+- Deterministic scoring (reproducible results)
+- Role-based personalization (different knowledge contexts)
+- No embedding model training required
+
+**vs. Obsidian/Logseq search:**
+Terraphim searches across tools, not within one tool. Your Obsidian notes + Confluence docs + GitHub repos + StackOverflow + bookmarked Twitter threads - all from one search query.
+
+Also, semantic graph search means "async cancellation" finds notes about "task cancellation" and "abort patterns" even if those exact words aren't present.
+
+**vs. OpenAI/Anthropic APIs:**
+Those are LLM APIs that process your data on their servers. Terraphim is a local search engine that optionally uses Ollama (local LLM) for summarization. Your data stays local.
+
+### For technical architecture questions:
+
+**Knowledge Graph vs Vector DB:**
+We use Aho-Corasick automata built from a semantic thesaurus. Benefits:
+- Explicit concept mapping (engineer knows what "relates to" what)
+- Fast O(n) text matching
+- Deterministic results
+- No embedding model dependencies
+- WASM-compatible (runs in browser)
+
+Trade-offs:
+- Requires building thesaurus (vs. auto-generated embeddings)
+- Less "fuzzy" matching (precise concept boundaries)
+
+For some use cases, vector DBs are better. For structured domain knowledge where you control the concept taxonomy, knowledge graphs give more predictable results.
+
+**Why Rust?**
+- Performance for text processing (matching millions of documents)
+- Memory safety for long-running service
+- WASM compilation for browser autocomplete
+- Strong async ecosystem (tokio)
+- Type safety across 29-crate workspace
+
+### For integration questions:
+
+**Twitter/X Integration:**
+Planning to use X API v2 to:
+- Index user's bookmarked tweets/threads
+- Track specific accounts' technical discussions
+- Extract concepts for thesaurus enrichment
+- Reconstruct thread context
+
+Challenges: Rate limits, thread reconstruction, incremental indexing. Will share updates on GitHub.
+
+**Why not Slack/Discord first?**
+Good question. X has unique value for public technical discourse - solutions shared in threads that aren't documented elsewhere. But Slack/Discord for team conversations is definitely on the roadmap. What would you prioritize?
+
+---
+
+## Follow-up Comment (Post-Submission)
+
+**After a few hours, post this as a top-level comment:**
+
+Author here. Few clarifications based on questions:
+
+**Installation is simple:**
+```bash
+# One-liner
+curl -fsSL https://raw.githubusercontent.com/terraphim/terraphim-ai/main/release/v0.2.3/install.sh | bash
+
+# Or Docker
+docker run ghcr.io/terraphim/terraphim-server:latest
+
+# Or Homebrew
+brew install terraphim/terraphim-ai/terraphim-ai
+```
+
+**LLM is optional:**
+The core search works without any LLM. If you want AI features (summarization, chat), plug in Ollama locally. No OpenAI API key needed.
+
+**Resource usage:**
+Rust backend is lightweight. The expensive part is building automata from large thesauruses - we cache these. Runtime search is O(n) on document text.
+
+**Mobile app?**
+Not yet. Desktop (Tauri), web UI, and TUI currently. Mobile would require rethinking the local-first architecture.
+
+**Commercial plans?**
+Open source under Apache 2.0. Might build hosted version for teams eventually, but core stays open and local-first.
+
+Happy to answer technical questions about the knowledge graph implementation or Rust architecture choices.

--- a/marketing/reddit-post.md
+++ b/marketing/reddit-post.md
@@ -1,0 +1,258 @@
+# Reddit Posts for Terraphim AI
+
+## r/LocalLLaMA Post
+
+**Title:** Terraphim AI: Privacy-first local AI assistant with knowledge graphs - now adding X/Twitter integration
+
+**Body:**
+
+Hey r/LocalLLaMA,
+
+I've been working on Terraphim AI, an open-source privacy-first AI assistant that runs entirely locally. Thought you'd appreciate the architecture and would love feedback.
+
+### The Problem
+
+Knowledge workers waste ~20% of their time searching for information across fragmented tools. Existing AI assistants require uploading your data to external servers - not ideal when you're dealing with proprietary code, private notes, or confidential documents.
+
+### What Terraphim Does
+
+It's a local search engine with knowledge graph semantics that unifies search across:
+
+- Local filesystem (Markdown, code files)
+- Personal knowledge bases (Obsidian, Logseq, Notion)
+- Team tools (Confluence, Jira)
+- Public sources (StackOverflow, GitHub, Reddit)
+- Email (JMAP)
+
+Everything runs locally. Your data never leaves your machine.
+
+### Technical Highlights
+
+**Knowledge Graph System:**
+- Custom Aho-Corasick automata for fast text matching
+- Multiple relevance functions (BM25, BM25F, BM25Plus, TitleScorer, TerraphimGraph)
+- Semantic thesaurus with concept expansion
+- Role-based personalization (different knowledge graphs for different contexts)
+
+**LLM Integration:**
+- Full Ollama support (local models)
+- OpenRouter integration (optional)
+- Document summarization
+- Context-aware AI chat
+
+**Architecture:**
+- Rust backend with async/await (tokio)
+- Svelte + Tauri desktop app
+- Terminal UI with REPL
+- MCP (Model Context Protocol) server for AI tool integration
+- Firecracker microVM support for secure execution (sub-2s boot times)
+
+### Why X/Twitter Integration?
+
+We're building X API integration to index:
+- Your bookmarked technical threads
+- Discussions from accounts you follow
+- Domain-specific conversations
+
+All stored in your local knowledge graph. When you search "async cancellation patterns", you get your notes + StackOverflow + that brilliant Twitter thread you saved 6 months ago.
+
+### Code Quality
+
+- Pre-commit hooks for fmt/lint
+- No mocks in tests (real integration testing)
+- Feature flags for optional functionality
+- Multi-platform CI/CD (GitHub Actions + Docker Buildx)
+
+### Try It
+
+```bash
+# Quick install
+curl -fsSL https://raw.githubusercontent.com/terraphim/terraphim-ai/main/release/v0.2.3/install.sh | bash
+
+# Or Docker
+docker run ghcr.io/terraphim/terraphim-server:latest
+
+# Or build from source
+git clone https://github.com/terraphim/terraphim-ai
+cargo build --release
+```
+
+**GitHub:** https://github.com/terraphim/terraphim-ai
+**Discord:** https://discord.gg/VPJXB6BGuY
+
+### Looking for Feedback
+
+- How do you currently manage scattered knowledge?
+- What local LLM models work best for your use cases?
+- Interest in other integrations? (Slack, Discord, etc.)
+
+Apache 2.0 licensed. PRs welcome.
+
+---
+
+## r/rust Post
+
+**Title:** [Show Reddit] Terraphim AI - Privacy-first knowledge search with Rust backend, knowledge graphs, and Firecracker VM integration
+
+**Body:**
+
+Built a privacy-first AI assistant in Rust. Here's the interesting technical bits:
+
+### Architecture
+
+29 library crates in a Cargo workspace:
+- `terraphim_service` - Main service layer
+- `terraphim_automata` - Aho-Corasick text matching + autocomplete
+- `terraphim_rolegraph` - Knowledge graph implementation
+- `terraphim_middleware` - Search orchestration
+- `terraphim_persistence` - Storage abstraction (memory, dashmap, sqlite, redb)
+- `terraphim_firecracker` - Firecracker microVM integration
+
+### Key Rust Patterns Used
+
+**Async everywhere with tokio:**
+```rust
+// Bounded channels for backpressure
+let (tx, rx) = tokio::sync::mpsc::channel(100);
+
+// Select for concurrent operations
+tokio::select! {
+    result = search_task => handle_search(result),
+    timeout = tokio::time::sleep(Duration::from_secs(5)) => handle_timeout(),
+}
+```
+
+**Knowledge Graph with Automata:**
+```rust
+// Fast text matching using Aho-Corasick
+pub fn find_matches(&self, text: &str) -> Vec<Match> {
+    self.automaton.find_overlapping_iter(text)
+        .map(|m| Match::new(m.pattern(), m.start(), m.end()))
+        .collect()
+}
+```
+
+**WASM Support:**
+`terraphim_automata` compiles to WebAssembly with `wasm-pack` for browser autocomplete.
+
+```bash
+# Build WASM module
+./scripts/build-wasm.sh web release
+```
+
+**Error Handling:**
+- `thiserror` for custom error types
+- `anyhow` for application errors
+- Result propagation with `?`
+- Graceful degradation (empty results vs panics)
+
+**Testing Philosophy:**
+- `tokio::test` for async tests
+- No mocks - real integration tests
+- Feature-gated live tests
+- `tokio::time::pause` for time-dependent tests
+
+### Firecracker Integration
+
+Sub-2 second VM boot times for secure command execution:
+- VM pooling for fast allocation
+- Knowledge graph validation before execution
+- Isolated file and web operations
+
+### Performance Considerations
+
+- Concurrent API calls with `tokio::join!`
+- Bounded channels for backpressure
+- Non-blocking operations throughout
+- Cache automata to avoid expensive rebuilds
+
+### X/Twitter Integration Plans
+
+Adding X API to index bookmarked technical threads into the local knowledge graph. Interesting challenges:
+- Rate limiting with backoff
+- Incremental indexing
+- Thread reconstruction
+- Semantic concept extraction from tweets
+
+### Links
+
+GitHub: https://github.com/terraphim/terraphim-ai
+
+Looking for feedback on:
+- Architecture decisions
+- Error handling patterns
+- Testing strategies for async code
+- Firecracker integration patterns
+
+Apache 2.0. Contributions welcome.
+
+---
+
+## r/selfhosted Post
+
+**Title:** Terraphim AI: Self-hosted privacy-first AI assistant that searches across local files, Notion, Obsidian, and more
+
+**Body:**
+
+For those who want AI assistance without cloud dependencies:
+
+### What is it?
+
+Terraphim AI is a self-hosted knowledge search engine that:
+- Runs 100% locally on your hardware
+- Searches across multiple knowledge sources from one interface
+- Uses knowledge graphs for semantic search (not just keywords)
+- Integrates with local LLMs (Ollama)
+
+### Supported Sources
+
+- Local filesystem (Markdown, code)
+- Obsidian, Logseq, Notion
+- Confluence, Jira
+- StackOverflow, GitHub, Reddit
+- Email (JMAP)
+- Custom sources via API
+
+### Installation
+
+**Docker:**
+```bash
+docker run ghcr.io/terraphim/terraphim-server:latest
+```
+
+**Direct install:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/terraphim/terraphim-ai/main/release/v0.2.3/install.sh | bash
+```
+
+**Homebrew:**
+```bash
+brew install terraphim/terraphim-ai/terraphim-ai
+```
+
+### Hardware Requirements
+
+- Works on ARM and x86_64
+- Docker images for linux/amd64, linux/arm64, linux/arm/v7
+- Minimal resource usage (Rust backend)
+- Ollama for local LLM (optional)
+
+### Why Self-Host?
+
+- Your private notes stay private
+- Proprietary code never leaves your network
+- No API costs or rate limits
+- Deterministic, reproducible behavior
+- Complete control over your AI assistant
+
+### Coming Soon
+
+X/Twitter API integration to index your bookmarked technical threads locally. All the knowledge from Twitter discussions, stored in your personal knowledge graph.
+
+### Links
+
+- GitHub: https://github.com/terraphim/terraphim-ai
+- Discord: https://discord.gg/VPJXB6BGuY
+- Apache 2.0 licensed
+
+Anyone running similar setups? How do you handle knowledge fragmentation?

--- a/marketing/x-twitter-thread.md
+++ b/marketing/x-twitter-thread.md
@@ -1,0 +1,157 @@
+# X (Twitter) Marketing Thread
+
+## Main Tweet (Thread Starter)
+
+Introducing Terraphim AI: Your privacy-first AI assistant that searches across ALL your knowledge sources - local files, Notion, Obsidian, GitHub, StackOverflow - without sending data to the cloud.
+
+Here's why we're building X API integration... [Thread]
+
+---
+
+## Tweet 2
+
+The problem: Your knowledge is scattered everywhere.
+
+- Personal notes in Obsidian
+- Team docs in Confluence
+- Code in GitHub
+- Discussions on X/Twitter
+
+Workers waste 20% of their time just FINDING information. That's 1 full day per week.
+
+---
+
+## Tweet 3
+
+Current AI assistants require uploading your data to third-party servers.
+
+Terraphim runs 100% locally. Your private conversations, proprietary code, and confidential documents stay on YOUR machine.
+
+Privacy isn't optional. It's the foundation.
+
+---
+
+## Tweet 4
+
+Why X API integration matters:
+
+X is where technical discussions happen in real-time. Bug solutions, architecture debates, breaking changes - all shared in threads.
+
+But X search is limited. We want to index YOUR relevant technical X conversations into your local knowledge graph.
+
+---
+
+## Tweet 5
+
+Imagine searching "how to handle async cancellation in Rust" and getting:
+
+- Your local notes
+- Your team's Confluence docs
+- Relevant StackOverflow answers
+- AND that brilliant thread from @rust_daily you bookmarked 6 months ago
+
+All from one local search. All private.
+
+---
+
+## Tweet 6
+
+Technical highlights:
+
+- Knowledge graph with semantic search (not just keyword matching)
+- BM25, TitleScorer, and graph-based ranking algorithms
+- Multiple scoring functions for personalized relevance
+- Sub-2 second Firecracker VM boot for secure execution
+- OpenRouter + Ollama for local LLM support
+
+---
+
+## Tweet 7
+
+Current integrations:
+
+- Local filesystem (Markdown, code)
+- Notion, Obsidian, Logseq
+- Confluence, Jira, SharePoint
+- StackOverflow, GitHub, Reddit
+- Email via JMAP
+- MCP (Model Context Protocol)
+
+X API would unlock social knowledge discovery.
+
+---
+
+## Tweet 8
+
+What X integration would enable:
+
+- Index bookmarked technical threads
+- Track discussions from accounts you follow
+- Build thesaurus from domain-specific X conversations
+- Connect X insights to your local knowledge graph
+- Semantic search across your X history
+
+All stored locally.
+
+---
+
+## Tweet 9
+
+Why we need your support:
+
+We're applying for X API access to build this integration right.
+
+If you believe in:
+- Privacy-first AI
+- Local-first software
+- Unified knowledge management
+
+Give us a follow and share this thread.
+
+---
+
+## Tweet 10
+
+Try Terraphim today:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/terraphim/terraphim-ai/main/release/v0.2.3/install.sh | bash
+```
+
+GitHub: github.com/terraphim/terraphim-ai
+Discord: discord.gg/VPJXB6BGuY
+
+Star the repo, join the community, help us build the future of private AI assistants.
+
+---
+
+## Shorter Single Tweet Versions
+
+### Version A (Feature Focus)
+Building @terraphim_ai: Privacy-first AI assistant that searches your local files, Notion, Obsidian, GitHub, StackOverflow - all from one place, all locally.
+
+Now adding X API to index your technical bookmarks into your personal knowledge graph.
+
+Open source. Try it: github.com/terraphim/terraphim-ai
+
+### Version B (Problem Focus)
+You waste 20% of your week searching for information scattered across tools.
+
+Terraphim AI: One local search across ALL your knowledge sources. No cloud upload. No privacy compromise.
+
+Adding X API integration to include your Twitter bookmarks in the mix.
+
+github.com/terraphim/terraphim-ai
+
+### Version C (Privacy Focus)
+Your AI assistant shouldn't need access to your private data.
+
+Terraphim runs 100% locally:
+- Search local files + cloud services
+- Knowledge graph semantics
+- LLM integration (Ollama/OpenRouter)
+- Privacy-first architecture
+
+Building X API integration next.
+
+github.com/terraphim/terraphim-ai


### PR DESCRIPTION
Create comprehensive marketing content targeting X, Reddit, Hacker News, and blog audiences to promote Terraphim AI's privacy-first architecture and planned X API integration for social knowledge discovery.