### PR TITLE
Review GitHub Actions failure and create fix

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -32,19 +32,19 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
-          cache: 'npm'
-          cache-dependency-path: desktop/package-lock.json
+          cache: 'yarn'
+          cache-dependency-path: desktop/yarn.lock
 
-      - name: Cache node modules and npm cache
+      - name: Cache node modules and yarn cache
         uses: actions/cache@v4
         with:
           path: |
             desktop/node_modules
-            ~/.npm
-          key: ${{ inputs.cache-key }}-npm-${{ inputs.node-version }}-${{ hashFiles('desktop/package-lock.json') }}
+            ~/.yarn
+          key: ${{ inputs.cache-key }}-yarn-${{ inputs.node-version }}-${{ hashFiles('desktop/yarn.lock') }}
           restore-keys: |
-            ${{ inputs.cache-key }}-npm-${{ inputs.node-version }}-
-            ${{ inputs.cache-key }}-npm-
+            ${{ inputs.cache-key }}-yarn-${{ inputs.node-version }}-
+            ${{ inputs.cache-key }}-yarn-
 
       - name: Set environment variables for CI
         env:

--- a/.github/workflows/release-comprehensive.yml
+++ b/.github/workflows/release-comprehensive.yml
@@ -19,16 +19,16 @@ jobs:
       matrix:
         include:
           # Linux builds
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             use_cross: false
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             use_cross: true
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             use_cross: true
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: armv7-unknown-linux-musleabihf
             use_cross: true
           # macOS builds
@@ -96,7 +96,7 @@ jobs:
 
   build-debian-packages:
     name: Build Debian packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -137,12 +137,16 @@ jobs:
         include:
           - platform: macos-latest
             webkit-package: ""
-          - platform: ubuntu-20.04
-            webkit-package: "libwebkit2gtk-4.0-dev"
+            javascriptcore-package: ""
           - platform: ubuntu-22.04
-            webkit-package: "libwebkit2gtk-4.0-dev"
+            webkit-package: "libwebkit2gtk-4.1-dev"
+            javascriptcore-package: "libjavascriptcoregtk-4.1-dev"
+          - platform: ubuntu-24.04
+            webkit-package: "libwebkit2gtk-4.1-dev"
+            javascriptcore-package: "libjavascriptcoregtk-4.1-dev"
           - platform: windows-latest
             webkit-package: ""
+            javascriptcore-package: ""
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
@@ -168,7 +172,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev ${{ matrix.webkit-package }} \
-            libjavascriptcoregtk-4.0-dev libsoup2.4-dev libayatana-appindicator3-dev librsvg2-dev pkg-config
+            ${{ matrix.javascriptcore-package }} libsoup2.4-dev libayatana-appindicator3-dev librsvg2-dev pkg-config
 
       - name: Install frontend dependencies
         working-directory: ./desktop

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.87.0
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4

--- a/.github/workflows/test-on-pr-desktop.yml
+++ b/.github/workflows/test-on-pr-desktop.yml
@@ -13,16 +13,16 @@ jobs:
         include:
           - platform: macos-latest
             webkit-package: ""
-          - platform: ubuntu-18.04
-            webkit-package: "libwebkit2gtk-4.0-dev"
-          - platform: ubuntu-20.04
-            webkit-package: "libwebkit2gtk-4.0-dev"
+            javascriptcore-package: ""
           - platform: ubuntu-22.04
-            webkit-package: "libwebkit2gtk-4.0-dev"
+            webkit-package: "libwebkit2gtk-4.1-dev"
+            javascriptcore-package: "libjavascriptcoregtk-4.1-dev"
           - platform: ubuntu-24.04
-            webkit-package: "libwebkit2gtk-4.0-dev"
+            webkit-package: "libwebkit2gtk-4.1-dev"
+            javascriptcore-package: "libjavascriptcoregtk-4.1-dev"
           - platform: windows-latest
             webkit-package: ""
+            javascriptcore-package: ""
 
     runs-on: ${{ matrix.platform }}
 
@@ -32,25 +32,23 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: latest
+          node-version: '20'
 
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Install dependencies (Ubuntu only)
         if: startsWith(matrix.platform, 'ubuntu-')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev ${{ matrix.webkit-package }} libjavascriptcoregtk-4.0-dev libsoup2.4-dev libayatana-appindicator3-dev librsvg2-dev pkg-config
+          sudo apt-get install -y libgtk-3-dev ${{ matrix.webkit-package }} ${{ matrix.javascriptcore-package }} libsoup2.4-dev libayatana-appindicator3-dev librsvg2-dev pkg-config
 
       - name: Install and Build Application
         run: yarn install && yarn build
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vm-execution-tests.yml
+++ b/.github/workflows/vm-execution-tests.yml
@@ -42,11 +42,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
         components: rustfmt, clippy
 
     - name: Cache cargo dependencies
@@ -112,11 +110,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
 
     - name: Install system dependencies
       run: |
@@ -212,11 +208,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
 
     - name: Cache cargo dependencies
       uses: actions/cache@v4
@@ -289,11 +283,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
 
     - name: Cache cargo dependencies
       uses: actions/cache@v4
@@ -381,11 +373,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
 
     - name: Cache cargo dependencies
       uses: actions/cache@v4
@@ -473,11 +463,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
 
     - name: Cache cargo dependencies
       uses: actions/cache@v4
@@ -612,11 +600,8 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust nightly
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
-        profile: minimal
-        override: true
         components: rustfmt, clippy, llvm-tools-preview
 
     - name: Install grcov


### PR DESCRIPTION
…tions

- Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchain
  - test-on-pr-desktop.yml (1 occurrence)
  - vm-execution-tests.yml (7 occurrences including nightly)
- Update removed/deprecated GitHub-hosted runners
  - Remove ubuntu-18.04 (no longer available since April 2023)
  - Update ubuntu-20.04 to ubuntu-22.04/24.04 where applicable
- Fix webkit and javascriptcore packages from 4.0 to 4.1 versions
- Update tauri-apps/tauri-action from v0 to v0.5
- Fix frontend-build.yml cache from npm to yarn (matches project config)
- Standardize Rust toolchain to 1.87.0 in tauri-build.yml