### PR TITLE
fix(ci): address four failing CI checks

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,6 +37,9 @@ jobs:
     name: Build Documentation
     runs-on: [self-hosted, linux, x64]
     steps:
+      - name: Pre-checkout cleanup
+        run: |
+          sudo rm -rf "${{ github.workspace }}/target" "${{ github.workspace }}/desktop/dist" "${{ github.workspace }}/desktop/node_modules" "${{ github.workspace }}/terraphim_server/dist" 2>/dev/null || true
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   deploy:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -27,6 +27,9 @@ jobs:
     name: Lint Python Code
     runs-on: [self-hosted, linux, x64]
     steps:
+      - name: Pre-checkout cleanup
+        run: |
+          sudo rm -rf "${{ github.workspace }}/target" "${{ github.workspace }}/desktop/dist" "${{ github.workspace }}/desktop/node_modules" "${{ github.workspace }}/terraphim_server/dist" 2>/dev/null || true
       - uses: actions/checkout@v6
 
       - name: Set up Python

--- a/crates/terraphim_automata/src/lib.rs
+++ b/crates/terraphim_automata/src/lib.rs
@@ -314,6 +314,7 @@ pub async fn load_thesaurus_from_json_and_replace_async(
 /// Note: Remote loading requires the "remote-loading" feature to be enabled.
 #[cfg(feature = "remote-loading")]
 pub async fn load_thesaurus(automata_path: &AutomataPath) -> Result<Thesaurus> {
+    #[allow(dead_code)]
     async fn read_url(url: String) -> Result<String> {
         log::debug!("Reading thesaurus from remote: {url}");
         let response = reqwest::Client::builder()


### PR DESCRIPTION
Cherry-pick CI fixes onto main:

- **terraphim_automata**: `#[allow(dead_code)]` for `read_url` (Quick Rust Validation)
- **deploy-docs.yml**: Pre-checkout cleanup of target/ on self-hosted (Build Documentation)
- **python-bindings.yml**: Pre-checkout cleanup of target/ on self-hosted (Lint Python Code)
- **deploy-website.yml**: Skip deploy job on pull_request (1password/setup not found on PRs)