### PR TITLE
refactor(agent): remove dead code and integrate McpToolsHandler

### DIFF
--- a/crates/terraphim_agent/src/onboarding/mod.rs
+++ b/crates/terraphim_agent/src/onboarding/mod.rs
@@ -43,10 +43,6 @@ pub enum OnboardingError {
     #[error("Validation failed: {0}")]
     Validation(String),
 
-    /// Configuration error from terraphim_config
-    #[error("Configuration error: {0}")]
-    Config(String),
-
     /// IO error during file operations
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -55,21 +51,9 @@ pub enum OnboardingError {
     #[error("Not a TTY - interactive mode requires a terminal. Use --template for non-interactive mode.")]
     NotATty,
 
-    /// Role with this name already exists
-    #[error("Role already exists: {0}")]
-    RoleExists(String),
-
     /// JSON serialization/deserialization error
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
-
-    /// Network error during URL validation
-    #[error("Network error: {0}")]
-    Network(String),
-
-    /// Path does not exist
-    #[error("Path does not exist: {0}")]
-    PathNotFound(String),
 
     /// User went back in wizard navigation
     #[error("User navigated back")]

--- a/crates/terraphim_agent/src/onboarding/prompts.rs
+++ b/crates/terraphim_agent/src/onboarding/prompts.rs
@@ -572,27 +572,6 @@ pub fn prompt_knowledge_graph() -> Result<PromptResult<Option<KnowledgeGraph>>, 
     }
 }
 
-/// Prompt for confirmation with custom message
-pub fn prompt_confirm(message: &str, default: bool) -> Result<bool, OnboardingError> {
-    let theme = ColorfulTheme::default();
-    Ok(Confirm::with_theme(&theme)
-        .with_prompt(message)
-        .default(default)
-        .interact()?)
-}
-
-/// Prompt for simple text input
-pub fn prompt_input(message: &str, default: Option<&str>) -> Result<String, OnboardingError> {
-    let theme = ColorfulTheme::default();
-    let mut input = Input::with_theme(&theme).with_prompt(message);
-
-    if let Some(d) = default {
-        input = input.default(d.to_string());
-    }
-
-    Ok(input.interact_text()?)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/terraphim_agent/src/onboarding/validation.rs
+++ b/crates/terraphim_agent/src/onboarding/validation.rs
@@ -26,10 +26,6 @@ pub enum ValidationError {
     #[error("Service {0} requires: {1}")]
     ServiceRequirement(String, String),
 
-    /// Path does not exist on filesystem
-    #[error("Path does not exist: {0}")]
-    PathNotFound(String),
-
     /// URL is malformed
     #[error("Invalid URL: {0}")]
     InvalidUrl(String),

--- a/crates/terraphim_agent/src/repl/mcp_tools.rs
+++ b/crates/terraphim_agent/src/repl/mcp_tools.rs
@@ -14,13 +14,11 @@ use terraphim_automata::LinkType;
 use terraphim_types::RoleName;
 
 #[cfg(feature = "repl-mcp")]
-#[allow(dead_code)] // Prepared for future MCP tool integration
 pub struct McpToolsHandler {
     service: Arc<TuiService>,
 }
 
 #[cfg(feature = "repl-mcp")]
-#[allow(dead_code)] // Prepared for future MCP tool integration
 impl McpToolsHandler {
     /// Create a new McpToolsHandler with a reference to the TuiService
     pub fn new(service: Arc<TuiService>) -> Self {

--- a/crates/terraphim_agent/src/service.rs
+++ b/crates/terraphim_agent/src/service.rs
@@ -119,7 +119,6 @@ impl TuiService {
     }
 
     /// Search documents using the current selected role
-    #[allow(dead_code)]
     pub async fn search(&self, search_term: &str, limit: Option<usize>) -> Result<Vec<Document>> {
         let selected_role = self.get_selected_role().await;
         self.search_with_role(search_term, &selected_role, limit)
@@ -277,7 +276,6 @@ impl TuiService {
     }
 
     /// Perform autocomplete search using thesaurus for a role
-    #[allow(dead_code)]
     pub async fn autocomplete(
         &self,
         role_name: &RoleName,
@@ -303,7 +301,6 @@ impl TuiService {
     }
 
     /// Find matches in text using thesaurus
-    #[allow(dead_code)]
     pub async fn find_matches(
         &self,
         role_name: &RoleName,
@@ -317,7 +314,6 @@ impl TuiService {
     }
 
     /// Replace matches in text with links using thesaurus
-    #[allow(dead_code)]
     pub async fn replace_matches(
         &self,
         role_name: &RoleName,
@@ -333,7 +329,6 @@ impl TuiService {
     }
 
     /// Summarize content using available AI services
-    #[allow(dead_code)]
     pub async fn summarize(&self, role_name: &RoleName, content: &str) -> Result<String> {
         // For now, use the chat method with a summarization prompt
         let prompt = format!("Please summarize the following content:\n\n{}", content);


### PR DESCRIPTION
## Summary

Remove dead code warnings and properly integrate McpToolsHandler into the REPL system.

## Changes

### McpToolsHandler Integration
- Remove #[allow(dead_code)] from McpToolsHandler (now actively used by REPL)
- Add mcp_handler field to ReplHandler with proper feature gating
- Update all MCP command handlers to use mcp_handler instead of calling service directly

### Wizard Refactoring
- Refactor custom_wizard() to use into_result() pattern
- Replace 6 verbose match blocks with clean .into_result()? calls
- Remove unused PromptResult import

### Dead Code Removal
- Remove unused error variants from OnboardingError: Config, RoleExists, Network
- Remove PathNotFound variant from ValidationError (never constructed)
- Remove unused utility functions: prompt_confirm, prompt_input
- Add #[cfg(test)] to is_first_run function (test-only)
- Remove #[allow(dead_code)] from service methods now used via McpToolsHandler

## Verification

- ✅ All 134 unit tests pass
- ✅ All 11 integration tests pass  
- ✅ No breaking changes
- ✅ Code quality improved (-152 lines net)

## Impact

- **No user-facing changes** - internal refactoring only
- **Improved maintainability** - removed dead code, simplified patterns
- **Better code organization** - McpToolsHandler properly integrated

Ready for review and merge.