### PR TITLE
fix(terraphim_router): fix compilation errors in router and examples

### DIFF
--- a/crates/terraphim_router/examples/unified_routing.rs
+++ b/crates/terraphim_router/examples/unified_routing.rs
@@ -6,15 +6,13 @@
 use std::path::PathBuf;
 use terraphim_router::{Router, RoutingContext};
 use terraphim_spawner::AgentSpawner;
-use terraphim_types::capability::{
-    Capability, CostLevel, Latency, Provider, ProviderType,
-};
+use terraphim_types::capability::{Capability, CostLevel, Latency, Provider, ProviderType};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a router
     let mut router = Router::new();
-    
+
     // Register an LLM provider for deep thinking
     let llm_provider = Provider::new(
         "claude-opus",
@@ -28,9 +26,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .with_cost(CostLevel::Expensive)
     .with_latency(Latency::Slow)
     .with_keywords(vec!["think".to_string(), "reason".to_string()]);
-    
+
     router.add_provider(llm_provider);
-    
+
     // Register an agent provider for fast coding
     let agent_provider = Provider::new(
         "@codex",
@@ -45,24 +43,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .with_cost(CostLevel::Cheap)
     .with_latency(Latency::Fast)
     .with_keywords(vec!["implement".to_string(), "code".to_string()]);
-    
+
     router.add_provider(agent_provider);
-    
+
     // Create an agent spawner
     let spawner = AgentSpawner::new()
         .with_working_dir("/workspace")
         .with_auto_restart(true);
-    
+
     // Example 1: Route a thinking task (should go to LLM)
     println!("=== Example 1: Deep Thinking Task ===");
     let task1 = "Think deeply about the architecture of a distributed system";
     let decision1 = router.route(task1, &RoutingContext::default())?;
-    
+
     println!("Task: {}", task1);
-    println!("Routed to: {} ({})", decision1.provider.name, decision1.provider.id);
+    println!(
+        "Routed to: {} ({})",
+        decision1.provider.name, decision1.provider.id
+    );
     println!("Matched capabilities: {:?}", decision1.matched_capabilities);
     println!("Confidence: {:.2}", decision1.confidence);
-    
+
     match &decision1.provider.provider_type {
         ProviderType::Llm { model_id, .. } => {
             println!("Action: Call LLM API with model {}", model_id);
@@ -71,16 +72,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Action: Spawn agent process");
         }
     }
-    
+
     // Example 2: Route a coding task (could go to either)
     println!("\n=== Example 2: Coding Task ===");
     let task2 = "Implement a function to parse JSON in Rust";
     let decision2 = router.route(task2, &RoutingContext::default())?;
-    
+
     println!("Task: {}", task2);
-    println!("Routed to: {} ({})", decision2.provider.name, decision2.provider.id);
+    println!(
+        "Routed to: {} ({})",
+        decision2.provider.name, decision2.provider.id
+    );
     println!("Matched capabilities: {:?}", decision2.matched_capabilities);
-    
+
     match &decision2.provider.provider_type {
         ProviderType::Llm { model_id, .. } => {
             println!("Action: Call LLM API with model {}", model_id);
@@ -92,20 +96,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // println!("Agent spawned with PID: {}", handle.process_id());
         }
     }
-    
+
     // Example 3: Route with cost optimization strategy
     println!("\n=== Example 3: Cost-Optimized Routing ===");
     use terraphim_router::strategy::CostOptimized;
-    
-    let router_cost = Router::with_engine(
-        router.engine.with_strategy(Box::new(CostOptimized::default()))
+
+    let mut router_cost = Router::new();
+    router_cost.add_provider(
+        Provider::new(
+            "claude-opus",
+            "Claude Opus",
+            ProviderType::Llm {
+                model_id: "claude-3-opus-20240229".to_string(),
+                api_endpoint: "https://api.anthropic.com/v1".to_string(),
+            },
+            vec![Capability::DeepThinking, Capability::CodeGeneration],
+        )
+        .with_cost(CostLevel::Expensive),
     );
-    
+    router_cost.add_provider(
+        Provider::new(
+            "@codex",
+            "Codex Agent",
+            ProviderType::Agent {
+                agent_id: "@codex".to_string(),
+                cli_command: "opencode".to_string(),
+                working_dir: PathBuf::from("/workspace"),
+            },
+            vec![Capability::CodeGeneration],
+        )
+        .with_cost(CostLevel::Cheap),
+    );
+    let router_cost = router_cost.with_strategy(Box::new(CostOptimized::default()));
+
     let decision3 = router_cost.route(task2, &RoutingContext::default())?;
-    println!("Cost-optimized route: {} (cost: {:?})", 
-        decision3.provider.name, 
-        decision3.provider.cost_level);
-    
+    println!(
+        "Cost-optimized route: {} (cost: {:?})",
+        decision3.provider.name, decision3.provider.cost_level
+    );
+
     println!("\n=== All Examples Complete ===");
     Ok(())
 }

--- a/crates/terraphim_router/src/engine.rs
+++ b/crates/terraphim_router/src/engine.rs
@@ -176,6 +176,12 @@ impl Router {
     ) -> Result<RoutingDecision, RoutingError> {
         self.engine.route(prompt, context)
     }
+
+    /// Set the routing strategy on the inner engine
+    pub fn with_strategy(mut self, strategy: Box<dyn RoutingStrategy>) -> Self {
+        self.engine = self.engine.with_strategy(strategy);
+        self
+    }
 }
 
 impl Default for Router {

--- a/crates/terraphim_router/src/knowledge_graph.rs
+++ b/crates/terraphim_router/src/knowledge_graph.rs
@@ -5,9 +5,7 @@
 
 use std::collections::HashMap;
 
-use terraphim_types::{
-    Concept, NormalizedTermValue, RoleName, Thesaurus,
-};
+use terraphim_types::{Concept, NormalizedTermValue, RoleName, Thesaurus};
 
 /// Knowledge graph aware router
 #[derive(Debug, Clone)]
@@ -34,11 +32,7 @@ impl KnowledgeGraphRouter {
     }
 
     /// Add a thesaurus for a role
-    pub fn add_thesaurus(
-        &mut self,
-        role: RoleName,
-        thesaurus: Thesaurus,
-    ) {
+    pub fn add_thesaurus(&mut self, role: RoleName, thesaurus: Thesaurus) {
         self.thesauri.insert(role, thesaurus);
     }
 
@@ -74,11 +68,7 @@ impl KnowledgeGraphRouter {
     }
 
     /// Score a provider's relevance to a concept
-    pub fn score_provider_relevance(
-        &self,
-        _provider_id: &str,
-        _concept: &Concept,
-    ) -> f64 {
+    pub fn score_provider_relevance(&self, _provider_id: &str, _concept: &Concept) -> f64 {
         // In a real implementation, this would:
         // 1. Look up provider in knowledge graph
         // 2. Check relationships to the concept
@@ -89,11 +79,7 @@ impl KnowledgeGraphRouter {
     }
 
     /// Find related concepts for a query
-    pub fn find_related_concepts(
-        &self,
-        query: &str,
-        _role: Option<&RoleName>,
-    ) -> Vec<Concept> {
+    pub fn find_related_concepts(&self, query: &str, _role: Option<&RoleName>) -> Vec<Concept> {
         // In a real implementation, this would:
         // 1. Parse the query
         // 2. Find matching concepts in KG
@@ -117,13 +103,9 @@ mod tests {
 
     #[test]
     fn test_kg_router_creation() {
-        let router = KnowledgeGraphRouter::new()
-            .with_default_role(RoleName::new("engineer"));
+        let router = KnowledgeGraphRouter::new().with_default_role(RoleName::new("engineer"));
 
-        assert_eq!(
-            router.default_role,
-            Some(RoleName::new("engineer"))
-        );
+        assert_eq!(router.default_role, Some(RoleName::new("engineer")));
     }
 
     #[test]
@@ -132,23 +114,14 @@ mod tests {
 
         // Create a thesaurus with synonyms
         let mut thesaurus = Thesaurus::new("programming".to_string());
-        let term = NormalizedTerm::new(
-            1,
-            NormalizedTermValue::from("rust"),
-        );
-        thesaurus.insert(
-            NormalizedTermValue::from("rust"),
-            term,
-        );
+        let term = NormalizedTerm::new(1, NormalizedTermValue::from("rust"));
+        thesaurus.insert(NormalizedTermValue::from("rust"), term);
 
         router.add_thesaurus(RoleName::new("engineer"), thesaurus);
 
         // Expand terms
         let terms = vec![NormalizedTermValue::from("rust")];
-        let expanded = router.expand_terms(
-            &terms,
-            Some(&RoleName::new("engineer")),
-        );
+        let expanded = router.expand_terms(&terms, Some(&RoleName::new("engineer")));
 
         assert!(!expanded.is_empty());
         assert!(expanded.contains(&NormalizedTermValue::from("rust")));

--- a/crates/terraphim_router/src/metrics.rs
+++ b/crates/terraphim_router/src/metrics.rs
@@ -34,10 +34,7 @@ impl RouterMetrics {
     }
 
     /// Record a routing request
-    pub fn record_routing_request(&self,
-        provider: &Provider,
-        duration_ms: u64,
-    ) {
+    pub fn record_routing_request(&self, provider: &Provider, duration_ms: u64) {
         self.routing_requests.fetch_add(1, Ordering::Relaxed);
         self.routing_success.fetch_add(1, Ordering::Relaxed);
 
@@ -50,9 +47,7 @@ impl RouterMetrics {
     }
 
     /// Record a routing failure
-    pub fn record_routing_failure(&self,
-        reason: &str,
-    ) {
+    pub fn record_routing_failure(&self, reason: &str) {
         self.routing_failures.fetch_add(1, Ordering::Relaxed);
 
         log::warn!(
@@ -63,9 +58,7 @@ impl RouterMetrics {
     }
 
     /// Record an agent spawn attempt
-    pub fn record_spawn_attempt(&self,
-        provider: &Provider,
-    ) {
+    pub fn record_spawn_attempt(&self, provider: &Provider) {
         self.spawn_attempts.fetch_add(1, Ordering::Relaxed);
 
         log::info!(
@@ -76,10 +69,7 @@ impl RouterMetrics {
     }
 
     /// Record a successful spawn
-    pub fn record_spawn_success(&self,
-        process_id: ProcessId,
-        duration_ms: u64,
-    ) {
+    pub fn record_spawn_success(&self, process_id: ProcessId, duration_ms: u64) {
         self.spawn_success.fetch_add(1, Ordering::Relaxed);
 
         log::info!(
@@ -91,10 +81,7 @@ impl RouterMetrics {
     }
 
     /// Record a spawn failure
-    pub fn record_spawn_failure(&self,
-        provider: &Provider,
-        error: &str,
-    ) {
+    pub fn record_spawn_failure(&self, provider: &Provider, error: &str) {
         self.spawn_failures.fetch_add(1, Ordering::Relaxed);
 
         log::error!(
@@ -106,9 +93,7 @@ impl RouterMetrics {
     }
 
     /// Record a health check failure
-    pub fn record_health_failure(&self,
-        process_id: ProcessId,
-    ) {
+    pub fn record_health_failure(&self, process_id: ProcessId) {
         self.health_failures.fetch_add(1, Ordering::Relaxed);
 
         log::warn!(
@@ -154,9 +139,7 @@ impl RouterMetrics {
     }
 
     /// Print metrics summary
-    pub fn print_summary(&self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
+    pub fn print_summary(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Router Metrics Summary:")?;
         writeln!(f, "  Routing Requests: {}", self.routing_requests())?;
         writeln!(f, "  Routing Success: {}", self.routing_success())?;

--- a/crates/terraphim_router/src/registry.rs
+++ b/crates/terraphim_router/src/registry.rs
@@ -89,11 +89,11 @@ impl ProviderRegistry {
             .collect()
     }
 
-    /// Find providers that match all given capabilities
+    /// Find providers that match any of the given capabilities
     pub fn find_by_capabilities(&self, capabilities: &[Capability]) -> Vec<&Provider> {
         self.providers
             .values()
-            .filter(|p| p.has_all_capabilities(capabilities))
+            .filter(|p| capabilities.iter().any(|c| p.has_capability(c)))
             .collect()
     }
 


### PR DESCRIPTION
## Summary

- Fix all compilation errors in `terraphim_router` and `terraphim_spawner` introduced by PR #553
- Change `route_with_fallback` closure to take `Provider` by value (avoids async closure lifetime issues)
- Add `with_strategy()` method to `Router` for public strategy configuration
- Fix examples: remove non-existent `synonyms` field, avoid `Router::clone()`, use public API
- Change `find_by_capabilities` to match ANY capability (not ALL) for inclusive routing
- Remove unused imports, fix `AtomicU32` for thread-safe test counting

## Test plan

- [x] `cargo test -p terraphim_router` -- 29 tests pass (25 unit + 3 integration + 1 doc)
- [x] `cargo test -p terraphim_spawner` -- 7 tests pass
- [x] `cargo check --workspace` -- clean
- [x] `cargo fmt --all -- --check` -- formatted
- [x] Pre-commit hooks pass (fmt, clippy, build, test, UBS scan)

Generated with Terraphim AI