### PR TITLE
chore(release): bump workspace version to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "grepapp_haystack"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "haystack_core",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "haystack_core"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "terraphim_types",
 ]
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "terraphim-cli"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "terraphim-repl"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "colored 2.2.0",
@@ -9667,7 +9667,7 @@ dependencies = [
 
 [[package]]
 name = "terraphim-session-analyzer"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -9706,7 +9706,7 @@ dependencies = [
 
 [[package]]
 name = "terraphim_agent"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -10187,7 +10187,7 @@ dependencies = [
 
 [[package]]
 name = "terraphim_middleware"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -10362,7 +10362,7 @@ dependencies = [
 
 [[package]]
 name = "terraphim_server"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -10447,7 +10447,7 @@ dependencies = [
 
 [[package]]
 name = "terraphim_sessions"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10533,14 +10533,14 @@ dependencies = [
 
 [[package]]
 name = "terraphim_test_utils"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "rustc_version",
 ]
 
 [[package]]
 name = "terraphim_tinyclaw"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["crates/terraphim_agent_application", "crates/terraphim_truthforge", 
 default-members = ["terraphim_server"]
 
 [workspace.package]
-version = "1.8.0"
+version = "1.10.0"
 edition = "2024"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Summary
- Bump workspace version from 1.8.0 to 1.10.0 for v1.10.0 release
- All three key binaries (terraphim_server, terraphim_agent, terraphim-cli) inherit workspace version

## Test plan
- [x] `cargo check` passes for all three binaries
- [x] `cargo metadata` reports 1.10.0 for all three
- [x] 138 unit tests pass
- [x] Tag v1.10.0 pushed to trigger release workflow

Generated with Terraphim AI