### PR TITLE
fix(docker): use pre-built frontend assets in Docker build

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -209,7 +209,6 @@ jobs:
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu-version }}
             RUST_VERSION=1.92.0
-            NODE_VERSION=20
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
@@ -229,7 +228,6 @@ jobs:
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu-version }}
             RUST_VERSION=1.92.0
-            NODE_VERSION=20
           cache-from: type=gha
           provenance: false
           sbom: false

--- a/docker/Dockerfile.multiarch
+++ b/docker/Dockerfile.multiarch
@@ -3,24 +3,16 @@
 
 ARG UBUNTU_VERSION=22.04
 ARG RUST_VERSION=1.85.0
-ARG NODE_VERSION=20
 
 # ================================
-# Frontend Build Stage
+# Frontend Assets Stage
 # ================================
-FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine AS frontend-builder
-
-WORKDIR /app
-# Copy package files - yarn.lock is optional
-COPY desktop/package*.json ./
-COPY desktop/yarn.lock* ./
-RUN yarn install --frozen-lockfile --network-timeout 300000
-
-COPY desktop ./
-RUN yarn run build
-
-# Verify frontend build
-RUN ls -la dist/ && test -f dist/index.html
+# Desktop has been moved to a separate repository.
+# The CI pipeline (docker-multiarch.yml) pre-builds the frontend
+# and places the dist/ output in the Docker build context at desktop/dist/.
+# We simply copy those pre-built assets here.
+FROM scratch AS frontend-assets
+COPY desktop/dist/ /dist/
 
 # ================================
 # Rust Build Stage
@@ -124,7 +116,7 @@ RUN . /root/.profile && \
 # Copy source code
 COPY crates ./crates
 COPY terraphim_server ./terraphim_server
-COPY --from=frontend-builder /app/dist ./terraphim_server/dist
+COPY --from=frontend-assets /dist ./terraphim_server/dist
 
 # Build the application
 RUN . /root/.profile && \


### PR DESCRIPTION
## Summary

- Replace the `frontend-builder` Alpine Node.js stage in `Dockerfile.multiarch` with a `frontend-assets` scratch stage that copies pre-built assets from the CI pipeline
- Remove unused `NODE_VERSION` build-arg from both GHCR and DockerHub build steps in `docker-multiarch.yml`

## Root Cause

The Docker 20.04 build in the v1.10.0 release workflow failed because:
1. The `frontend-builder` stage used `node:20-alpine`
2. `svelma` could not resolve `bulma/sass/utilities/all` in the Alpine Sass environment
3. The CI pipeline **already pre-builds** the frontend on `ubuntu-22.04` and downloads it to `desktop/dist/` in the Docker build context (via `build-frontend` job + artifact download)
4. The Dockerfile ignored those pre-built assets and attempted to rebuild from source, which failed

## Fix

Replace the 15-line Node.js Alpine build stage with a 2-line scratch copy:
```dockerfile
FROM scratch AS frontend-assets
COPY desktop/dist/ /dist/
```

This also prepares for the desktop being moved to a separate repository, where in-container frontend builds would not be possible.

## Test plan

- [ ] Verify Docker build succeeds for both Ubuntu 20.04 and 22.04 matrices
- [ ] Verify the frontend dist is correctly copied into `terraphim_server/dist` in the final image
- [ ] Verify GHCR push succeeds

Generated with [Terraphim AI](https://github.com/terraphim/terraphim-ai)