### PR TITLE
fix(ci): add missing version fields for crates.io publishing

### DIFF
--- a/crates/terraphim_router/Cargo.toml
+++ b/crates/terraphim_router/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/terraphim/terraphim-ai"
 
 [dependencies]
 # Terraphim internal crates
-terraphim_types = { path = "../terraphim_types" }
+terraphim_types = { path = "../terraphim_types", version = "1.0.0" }
 
 # Core dependencies
 serde = { version = "1.0", features = ["derive"] }
@@ -28,6 +28,7 @@ dirs = "5.0"
 # Optional persistence support
 [dependencies.terraphim_persistence]
 path = "../terraphim_persistence"
+version = "1.0.0"
 optional = true
 
 # Optional file-watching support

--- a/crates/terraphim_service/Cargo.toml
+++ b/crates/terraphim_service/Cargo.toml
@@ -39,7 +39,7 @@ reqwest = { workspace = true }
 once_cell = "1.19"
 
 # LLM Router integration
-terraphim_router = { path = "../terraphim_router", optional = true }
+terraphim_router = { path = "../terraphim_router", version = "1.0.0", optional = true }
 
 # Logging utilities
 env_logger = "0.11"

--- a/crates/terraphim_spawner/Cargo.toml
+++ b/crates/terraphim_spawner/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/terraphim/terraphim-ai"
 
 [dependencies]
 # Terraphim internal crates
-terraphim_types = { path = "../terraphim_types" }
-terraphim_router = { path = "../terraphim_router" }
+terraphim_types = { path = "../terraphim_types", version = "1.0.0" }
+terraphim_router = { path = "../terraphim_router", version = "1.0.0" }
 
 # Core dependencies
 tokio = { version = "1.0", features = ["full"] }

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -49,6 +49,8 @@ CRATES=(
   "terraphim_automata"
   "terraphim_config"
   "terraphim_rolegraph"
+  "terraphim_router"
+  "terraphim_spawner"
   "terraphim_hooks"
   "terraphim-session-analyzer"
   "haystack_core"


### PR DESCRIPTION
## Summary
- Add `version = "1.0.0"` to path-only dependencies that break `cargo publish`
- Add `terraphim_router` and `terraphim_spawner` to the publish script's crate list

## Root Cause

The v1.10.0 release failed at `Publish Rust crates to crates.io` with:

```
error: all dependencies must have a version requirement specified when publishing.
dependency `terraphim_router` does not specify a version
```

`terraphim_service` depends on `terraphim_router` with `path = "../terraphim_router"` but no `version` field. When `cargo publish` packages a crate, it strips the `path` and uses only the `version` to resolve from crates.io. Without a version, it fails.

Additionally, `terraphim_router` and `terraphim_spawner` were not in `publish-crates.sh`'s dependency-ordered crate list, so they would never be published even if the version was specified.

## Changes

| File | Change |
|------|--------|
| `crates/terraphim_service/Cargo.toml` | Add `version = "1.0.0"` to `terraphim_router` dep |
| `crates/terraphim_router/Cargo.toml` | Add `version = "1.0.0"` to `terraphim_types` and `terraphim_persistence` deps |
| `crates/terraphim_spawner/Cargo.toml` | Add `version = "1.0.0"` to `terraphim_types` and `terraphim_router` deps |
| `scripts/publish-crates.sh` | Add `terraphim_router` and `terraphim_spawner` to `CRATES` array |

## Test plan
- [ ] `cargo check -p terraphim_router -p terraphim_spawner -p terraphim_service` passes
- [ ] Re-tag v1.10.0 after merge to trigger full release rebuild
- [ ] Verify "Publish Rust crates to crates.io" step passes

Generated with [Terraphim AI](https://github.com/terraphim/terraphim-ai)