### PR TITLE
fix(ci): scope publish script version sed to package section only

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -193,11 +193,13 @@ update_versions() {
     if [[ -f "$crate_path" ]]; then
       log_info "Updating $crate to version $VERSION"
 
-      # Update version in Cargo.toml
+      # Update ONLY the [package] version in Cargo.toml (first occurrence).
+      # Using 0,/pattern/ (GNU sed) or 1,/pattern/ (BSD sed) to avoid
+      # corrupting dependency version lines in [dependencies.X] sections.
       if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" "$crate_path"
+        sed -i '' '1,/^version = ".*"/s/^version = ".*"/version = "'"$VERSION"'"/' "$crate_path"
       else
-        sed -i "s/^version = \".*\"/version = \"$VERSION\"/" "$crate_path"
+        sed -i '0,/^version = ".*"/s/^version = ".*"/version = "'"$VERSION"'"/' "$crate_path"
       fi
 
       # Update workspace dependencies


### PR DESCRIPTION
## Summary
- The `update_versions` function in `publish-crates.sh` used `sed "s/^version = \".*\"/.../"`  which replaced **all** lines starting with `version = "` -- including dependency versions under `[dependencies.X]` sections
- This corrupted `notify`'s version from `"6.1"` to `"1.10.0"` in `terraphim_router/Cargo.toml`, causing `cargo publish` to fail with `failed to select a version for the requirement notify = "^1.10.0"`
- Fix: use sed range addressing (`0,/pattern/` on GNU, `1,/pattern/` on BSD) to only replace the first occurrence -- the `[package]` version line

## Test plan
- [x] Verified locally: `sed -i '0,/^version = ".*"/s/.../.../' terraphim_router/Cargo.toml` changes only line 3 (package version), leaves `notify` version `"6.1"` on line 36 untouched
- [ ] Re-tag v1.10.0 and verify `cargo publish` passes for `terraphim_router`

Generated with [Terraphim AI](https://terraphim.ai)