### PR TITLE
refactor: remove unused mockall, fix flaky tests

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -67,7 +67,7 @@ lru = "0.16"
 tokio-test = "0.4.4"
 serial_test = "3.3.1"
 tempfile = "3.23.0"
-mockall = "0.14.0"
+
 
 [features]
 # by default Tauri runs in production mode


### PR DESCRIPTION
## Summary
- Remove `mockall = "0.14.0"` from `desktop/src-tauri` dev-dependencies (never used)
- Fix 2 flaky tests that fail when run as part of workspace:
  - `test_save_one_memory`: handle global storage singleton race condition
  - `test_circuit_breaker_half_open_after_cooldown`: increase timing margin

Most dependency duplicates (ahash 0.7/0.8, toml 0.5/0.9, thiserror 1.0/2.0) are transitive via upstream crates and cannot be resolved without breaking changes.

## Test plan
- [x] `cargo test --workspace --lib` passes (all tests green)
- [x] `cargo check --workspace` passes
- [x] Pre-commit hooks pass

Closes #627

Generated with Terraphim AI