### PR TITLE
feat(learn): session-based auto-capture for procedures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9087,6 +9087,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "terraphim_automata",

--- a/crates/terraphim_agent/src/learnings/mod.rs
+++ b/crates/terraphim_agent/src/learnings/mod.rs
@@ -26,7 +26,7 @@
 pub(crate) mod capture;
 mod hook;
 mod install;
-mod procedure;
+pub(crate) mod procedure;
 pub(crate) mod redaction;
 mod replay;
 

--- a/crates/terraphim_agent/src/learnings/procedure.rs
+++ b/crates/terraphim_agent/src/learnings/procedure.rs
@@ -390,6 +390,136 @@ impl ProcedureStore {
     }
 }
 
+/// Commands considered trivial and excluded from session-to-procedure extraction.
+///
+/// These are navigational, informational, or read-only commands that do not
+/// contribute meaningful steps to a procedure.
+pub const TRIVIAL_COMMANDS: &[&str] = &[
+    "cd ", "ls", "pwd", "echo ", "cat ", "head ", "tail ", "wc ", "which ", "type ", "date",
+    "whoami",
+];
+
+/// Check whether a command is trivial (should be excluded from procedure extraction).
+fn is_trivial_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    TRIVIAL_COMMANDS
+        .iter()
+        .any(|prefix| trimmed == prefix.trim() || trimmed.starts_with(prefix))
+}
+
+/// Create a `CapturedProcedure` from a list of (command, exit_code) pairs.
+///
+/// This is the core extraction logic for session-based auto-capture.
+/// It filters out trivial commands (cd, ls, pwd, etc.) and commands that
+/// failed (exit_code != 0), then maps the remaining commands to ordered
+/// `ProcedureStep` entries.
+///
+/// # Arguments
+///
+/// * `commands` - A list of `(command_string, exit_code)` tuples extracted from a session.
+/// * `title` - Optional title. If `None`, auto-generates from the first meaningful command.
+///
+/// # Returns
+///
+/// A `CapturedProcedure` with steps derived from the successful, non-trivial commands.
+pub fn from_session_commands(
+    commands: Vec<(String, i32)>,
+    title: Option<String>,
+) -> CapturedProcedure {
+    use terraphim_types::procedure::ProcedureStep;
+    use uuid::Uuid;
+
+    // Filter: only successful, non-trivial commands
+    let meaningful: Vec<&str> = commands
+        .iter()
+        .filter(|(_, exit_code)| *exit_code == 0)
+        .map(|(cmd, _)| cmd.as_str())
+        .filter(|cmd| !is_trivial_command(cmd))
+        .collect();
+
+    // Auto-generate title from first meaningful command if not provided
+    let generated_title = title.unwrap_or_else(|| {
+        if let Some(first) = meaningful.first() {
+            let truncated = if first.len() > 60 {
+                format!("{}...", &first[..60])
+            } else {
+                (*first).to_string()
+            };
+            format!("Session: {}", truncated)
+        } else {
+            "Session procedure (empty)".to_string()
+        }
+    });
+
+    let description = format!(
+        "Auto-captured from session ({} steps from {} commands)",
+        meaningful.len(),
+        commands.len()
+    );
+
+    let id = Uuid::new_v4().to_string();
+    let mut procedure = CapturedProcedure::new(id, generated_title, description);
+
+    for (ordinal, cmd) in meaningful.iter().enumerate() {
+        procedure.add_step(ProcedureStep {
+            ordinal: (ordinal + 1) as u32,
+            command: cmd.to_string(),
+            precondition: None,
+            postcondition: None,
+            working_dir: None,
+            privileged: false,
+            tags: vec![],
+        });
+    }
+
+    procedure
+}
+
+/// Extract Bash commands with success/failure status from a session.
+///
+/// Pairs `ToolUse` blocks (where `name == "Bash"`) with their corresponding
+/// `ToolResult` blocks using the `tool_use_id` linkage. Returns a list of
+/// `(command, exit_code)` pairs where exit_code is 0 for success and 1 for error.
+#[cfg(feature = "repl-sessions")]
+pub fn extract_bash_commands_from_session(
+    session: &terraphim_sessions::Session,
+) -> Vec<(String, i32)> {
+    use terraphim_sessions::ContentBlock;
+
+    // Collect all ToolResult blocks indexed by tool_use_id
+    let mut results: std::collections::HashMap<&str, bool> = std::collections::HashMap::new();
+    for msg in &session.messages {
+        for block in &msg.blocks {
+            if let ContentBlock::ToolResult {
+                tool_use_id,
+                is_error,
+                ..
+            } = block
+            {
+                results.insert(tool_use_id.as_str(), *is_error);
+            }
+        }
+    }
+
+    // Collect Bash ToolUse blocks and match with results
+    let mut commands = Vec::new();
+    for msg in &session.messages {
+        for block in &msg.blocks {
+            if let ContentBlock::ToolUse { id, name, input } = block {
+                if name == "Bash" {
+                    if let Some(cmd) = input.get("command").and_then(|v| v.as_str()) {
+                        let is_error = results.get(id.as_str()).copied().unwrap_or(false);
+                        let exit_code = if is_error { 1 } else { 0 };
+                        commands.push((cmd.to_string(), exit_code));
+                    }
+                }
+            }
+        }
+    }
+
+    commands
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -723,5 +853,272 @@ mod tests {
 
         let not_found = store.find_by_id("nonexistent").unwrap();
         assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_from_session_commands_basic() {
+        use super::from_session_commands;
+
+        let commands = vec![
+            ("cargo build".to_string(), 0),
+            ("cargo test".to_string(), 0),
+            ("cargo clippy".to_string(), 0),
+        ];
+
+        let proc = from_session_commands(commands, Some("Build and test".to_string()));
+
+        assert_eq!(proc.title, "Build and test");
+        assert_eq!(proc.steps.len(), 3);
+        assert_eq!(proc.steps[0].ordinal, 1);
+        assert_eq!(proc.steps[0].command, "cargo build");
+        assert_eq!(proc.steps[1].ordinal, 2);
+        assert_eq!(proc.steps[1].command, "cargo test");
+        assert_eq!(proc.steps[2].ordinal, 3);
+        assert_eq!(proc.steps[2].command, "cargo clippy");
+        assert!(proc.description.contains("3 steps"));
+    }
+
+    #[test]
+    fn test_from_session_commands_filters_trivial() {
+        use super::from_session_commands;
+
+        let commands = vec![
+            ("cd /tmp".to_string(), 0),
+            ("ls".to_string(), 0),
+            ("cargo build".to_string(), 0),
+            ("pwd".to_string(), 0),
+            ("echo hello".to_string(), 0),
+            ("cargo test".to_string(), 0),
+            ("cat README.md".to_string(), 0),
+            ("head -5 file.txt".to_string(), 0),
+            ("tail -10 log.txt".to_string(), 0),
+            ("wc -l file.txt".to_string(), 0),
+            ("which cargo".to_string(), 0),
+            ("type cargo".to_string(), 0),
+            ("date".to_string(), 0),
+            ("whoami".to_string(), 0),
+        ];
+
+        let proc = from_session_commands(commands, Some("Filtered".to_string()));
+
+        // Only cargo build and cargo test should remain
+        assert_eq!(proc.steps.len(), 2);
+        assert_eq!(proc.steps[0].command, "cargo build");
+        assert_eq!(proc.steps[1].command, "cargo test");
+    }
+
+    #[test]
+    fn test_from_session_commands_filters_failures() {
+        use super::from_session_commands;
+
+        let commands = vec![
+            ("cargo build".to_string(), 0),
+            ("cargo test".to_string(), 1), // failed
+            ("cargo clippy".to_string(), 0),
+        ];
+
+        let proc = from_session_commands(commands, Some("With failures".to_string()));
+
+        assert_eq!(proc.steps.len(), 2);
+        assert_eq!(proc.steps[0].command, "cargo build");
+        assert_eq!(proc.steps[1].command, "cargo clippy");
+    }
+
+    #[test]
+    fn test_from_session_commands_auto_title() {
+        use super::from_session_commands;
+
+        let commands = vec![
+            ("ls".to_string(), 0),          // trivial, skipped
+            ("cargo build".to_string(), 0), // first meaningful
+            ("cargo test".to_string(), 0),
+        ];
+
+        let proc = from_session_commands(commands, None);
+
+        assert_eq!(proc.title, "Session: cargo build");
+    }
+
+    #[test]
+    fn test_from_session_commands_auto_title_long_command() {
+        use super::from_session_commands;
+
+        let long_cmd = "a".repeat(100);
+        let commands = vec![(long_cmd.clone(), 0)];
+
+        let proc = from_session_commands(commands, None);
+
+        // Title should be truncated to 60 chars + "..."
+        assert!(proc.title.starts_with("Session: "));
+        assert!(proc.title.ends_with("..."));
+        assert!(proc.title.len() < 80);
+    }
+
+    #[test]
+    fn test_from_session_commands_empty() {
+        use super::from_session_commands;
+
+        let commands: Vec<(String, i32)> = vec![];
+        let proc = from_session_commands(commands, None);
+
+        assert_eq!(proc.title, "Session procedure (empty)");
+        assert_eq!(proc.steps.len(), 0);
+    }
+
+    #[test]
+    fn test_from_session_commands_all_trivial() {
+        use super::from_session_commands;
+
+        let commands = vec![
+            ("ls".to_string(), 0),
+            ("pwd".to_string(), 0),
+            ("cd /tmp".to_string(), 0),
+        ];
+
+        let proc = from_session_commands(commands, None);
+
+        assert_eq!(proc.title, "Session procedure (empty)");
+        assert_eq!(proc.steps.len(), 0);
+    }
+
+    #[test]
+    fn test_is_trivial_command() {
+        use super::is_trivial_command;
+
+        assert!(is_trivial_command("ls"));
+        assert!(is_trivial_command("ls -la"));
+        assert!(is_trivial_command("cd /tmp"));
+        assert!(is_trivial_command("pwd"));
+        assert!(is_trivial_command("echo hello"));
+        assert!(is_trivial_command("cat file.txt"));
+        assert!(is_trivial_command("date"));
+        assert!(is_trivial_command("whoami"));
+
+        assert!(!is_trivial_command("cargo build"));
+        assert!(!is_trivial_command("git status"));
+        assert!(!is_trivial_command("make install"));
+        assert!(!is_trivial_command("docker compose up"));
+    }
+
+    #[cfg(feature = "repl-sessions")]
+    #[test]
+    fn test_extract_bash_commands_from_session() {
+        use super::extract_bash_commands_from_session;
+        use std::path::PathBuf;
+        use terraphim_sessions::{ContentBlock, Message, MessageRole, Session, SessionMetadata};
+
+        let mut msg1 = Message::text(0, MessageRole::Assistant, "building");
+        msg1.blocks.push(ContentBlock::ToolUse {
+            id: "tu1".to_string(),
+            name: "Bash".to_string(),
+            input: serde_json::json!({"command": "cargo build"}),
+        });
+
+        let mut msg2 = Message::text(1, MessageRole::Tool, "result1");
+        msg2.blocks.push(ContentBlock::ToolResult {
+            tool_use_id: "tu1".to_string(),
+            content: "success".to_string(),
+            is_error: false,
+        });
+
+        let mut msg3 = Message::text(2, MessageRole::Assistant, "testing");
+        msg3.blocks.push(ContentBlock::ToolUse {
+            id: "tu2".to_string(),
+            name: "Bash".to_string(),
+            input: serde_json::json!({"command": "cargo test"}),
+        });
+
+        let mut msg4 = Message::text(3, MessageRole::Tool, "result2");
+        msg4.blocks.push(ContentBlock::ToolResult {
+            tool_use_id: "tu2".to_string(),
+            content: "error".to_string(),
+            is_error: true,
+        });
+
+        // Non-Bash tool use should be ignored
+        let mut msg5 = Message::text(4, MessageRole::Assistant, "reading");
+        msg5.blocks.push(ContentBlock::ToolUse {
+            id: "tu3".to_string(),
+            name: "Read".to_string(),
+            input: serde_json::json!({"file_path": "/some/file.rs"}),
+        });
+
+        let session = Session {
+            id: "test-session".to_string(),
+            source: "test".to_string(),
+            external_id: "test".to_string(),
+            title: Some("Test session".to_string()),
+            source_path: PathBuf::from("."),
+            started_at: None,
+            ended_at: None,
+            messages: vec![msg1, msg2, msg3, msg4, msg5],
+            metadata: SessionMetadata::default(),
+        };
+
+        let commands = extract_bash_commands_from_session(&session);
+
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0], ("cargo build".to_string(), 0));
+        assert_eq!(commands[1], ("cargo test".to_string(), 1));
+    }
+
+    #[cfg(feature = "repl-sessions")]
+    #[test]
+    fn test_extract_and_convert_session_to_procedure() {
+        use super::{extract_bash_commands_from_session, from_session_commands};
+        use std::path::PathBuf;
+        use terraphim_sessions::{ContentBlock, Message, MessageRole, Session, SessionMetadata};
+
+        // Build a session with mixed commands
+        let mut messages = Vec::new();
+
+        let bash_cmds = vec![
+            ("tu1", "ls -la", false),
+            ("tu2", "cargo build --release", false),
+            ("tu3", "cargo test", true), // failed
+            ("tu4", "cd /tmp", false),   // trivial
+            ("tu5", "cargo clippy", false),
+        ];
+
+        for (id, cmd, is_error) in &bash_cmds {
+            let mut tool_msg = Message::text(messages.len(), MessageRole::Assistant, "cmd");
+            tool_msg.blocks.push(ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: "Bash".to_string(),
+                input: serde_json::json!({"command": cmd}),
+            });
+            messages.push(tool_msg);
+
+            let mut result_msg = Message::text(messages.len(), MessageRole::Tool, "result");
+            result_msg.blocks.push(ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                content: "output".to_string(),
+                is_error: *is_error,
+            });
+            messages.push(result_msg);
+        }
+
+        let session = Session {
+            id: "integration-test".to_string(),
+            source: "test".to_string(),
+            external_id: "test".to_string(),
+            title: Some("Integration test".to_string()),
+            source_path: PathBuf::from("."),
+            started_at: None,
+            ended_at: None,
+            messages,
+            metadata: SessionMetadata::default(),
+        };
+
+        let commands = extract_bash_commands_from_session(&session);
+        assert_eq!(commands.len(), 5); // All 5 Bash commands extracted
+
+        let proc = from_session_commands(commands, None);
+        // ls (trivial), cargo build (ok), cargo test (failed), cd (trivial), cargo clippy (ok)
+        // Only cargo build and cargo clippy should remain
+        assert_eq!(proc.steps.len(), 2);
+        assert_eq!(proc.steps[0].command, "cargo build --release");
+        assert_eq!(proc.steps[1].command, "cargo clippy");
+        assert!(proc.title.starts_with("Session: cargo build --release"));
     }
 }

--- a/crates/terraphim_agent/src/main.rs
+++ b/crates/terraphim_agent/src/main.rs
@@ -917,6 +917,15 @@ enum ProcedureSub {
         /// Procedure ID
         id: String,
     },
+    /// Auto-capture a procedure from a session's Bash commands
+    #[cfg(feature = "repl-sessions")]
+    FromSession {
+        /// Session ID to extract commands from
+        session_id: String,
+        /// Optional title (auto-generated from first command if not provided)
+        #[arg(long)]
+        title: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -2508,6 +2517,55 @@ async fn run_learn_command(sub: LearnSub) -> Result<()> {
                     store.set_disabled(&id, true)?;
                     println!("Procedure '{}' disabled.", id);
                     Ok(())
+                }
+                #[cfg(feature = "repl-sessions")]
+                ProcedureSub::FromSession { session_id, title } => {
+                    use terraphim_sessions::SessionService;
+
+                    let service = SessionService::new();
+
+                    // Load cached sessions from disk
+                    let cache_path = get_session_cache_path();
+                    if cache_path.exists() {
+                        if let Ok(data) = std::fs::read_to_string(&cache_path) {
+                            if let Ok(cached) =
+                                serde_json::from_str::<Vec<terraphim_sessions::Session>>(&data)
+                            {
+                                service.load_sessions(cached).await;
+                            }
+                        }
+                    }
+
+                    let session = service.get_session(&session_id).await;
+                    match session {
+                        Some(sess) => {
+                            let commands =
+                                learnings::procedure::extract_bash_commands_from_session(&sess);
+                            if commands.is_empty() {
+                                println!("No Bash commands found in session '{}'.", session_id);
+                                return Ok(());
+                            }
+                            let total_cmds = commands.len();
+                            let mut procedure =
+                                learnings::procedure::from_session_commands(commands, title);
+                            procedure.source_session = Some(session_id.clone());
+                            let step_count = procedure.step_count();
+
+                            let saved = store.save_with_dedup(procedure)?;
+                            println!(
+                                "Created procedure '{}' (ID: {}) with {} steps from {} commands.",
+                                saved.title, saved.id, step_count, total_cmds
+                            );
+                            Ok(())
+                        }
+                        None => {
+                            eprintln!(
+                                "Session '{}' not found. Try running 'sessions list' first to import sessions.",
+                                session_id
+                            );
+                            std::process::exit(1);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add `learn procedure from-session` CLI for extracting procedures from AI coding session history
- Filters trivial commands (cd, ls, pwd, echo, etc.) and failed commands
- Auto-generates title from first meaningful command
- Pairs ToolUse/ToolResult blocks via tool_use_id for accurate exit code extraction
- Feature-gated behind `repl-sessions`

## New CLI

```
terraphim-agent learn procedure from-session <SESSION_ID> [--title "Title"]
```

## Test plan

- [x] 151 lib tests pass
- [x] 12 procedure CLI integration tests pass (backward compat)
- [x] 9 new unit tests for session extraction
- [x] Compiles with and without repl-sessions feature
- [x] Verified through right-side-of-v (all 7 tasks PASS)
- [x] cargo clippy clean

Refs #693