### PR TITLE
fix(ci): restore main validation after #788

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -499,9 +499,7 @@ jobs:
       - name: Run cargo audit
         run: |
           cargo install cargo-audit --no-default-features
-          # Fetch fresh advisory database to handle CVSS format updates
-          cargo audit --fetch || true
-          # Run audit, continuing on advisory DB parse errors (CVSS 4.0 format issue)
+          # Run audit, allowing warnings while keeping the advisory DB fresh.
           cargo audit || echo "::warning::cargo audit found issues or had parsing errors"
 
       - name: Run cargo deny

--- a/crates/terraphim_agent/tests/cross_mode_consistency_test.rs
+++ b/crates/terraphim_agent/tests/cross_mode_consistency_test.rs
@@ -300,27 +300,41 @@ fn search_via_cli(server_url: &str, query: &str, role: &str) -> Result<Vec<Norma
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Parse text format output: "- RANK\tTITLE" per line
+    // Parse human output lines. Current CLI output is "[RANK] TITLE",
+    // but keep support for the older "- RANK\tTITLE" form so the test
+    // tracks semantic consistency instead of a presentation detail.
     let results: Vec<NormalizedResult> = stdout
         .lines()
         .filter_map(|line| {
-            // Skip log lines and empty lines
-            if !line.starts_with("- ") {
-                return None;
+            if let Some(rest) = line.strip_prefix("- ") {
+                let parts: Vec<&str> = rest.splitn(2, '\t').collect();
+                if parts.len() >= 2 {
+                    let rank = parts[0].trim().parse::<u64>().ok();
+                    let title = parts[1].trim().to_string();
+                    return Some(NormalizedResult {
+                        id: title.clone(),
+                        title,
+                        rank,
+                    });
+                }
             }
-            let rest = line.strip_prefix("- ")?;
-            // Format is "RANK\tTITLE"
-            let parts: Vec<&str> = rest.splitn(2, '\t').collect();
-            if parts.len() >= 2 {
-                let rank = parts[0].trim().parse::<u64>().ok();
-                let title = parts[1].trim().to_string();
-                Some(NormalizedResult {
-                    id: title.clone(),
-                    title,
-                    rank,
-                })
-            } else {
+
+            let trimmed = line.trim();
+            let closing_bracket = trimmed.find(']')?;
+            let rank_str = trimmed
+                .strip_prefix('[')?
+                .get(..closing_bracket - 1)?
+                .trim();
+            let title = trimmed.get(closing_bracket + 1..)?.trim();
+
+            if title.is_empty() {
                 None
+            } else {
+                Some(NormalizedResult {
+                    id: title.to_string(),
+                    title: title.to_string(),
+                    rank: rank_str.parse::<u64>().ok(),
+                })
             }
         })
         .collect();

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,9 @@ ignore = [
     # Disabled by default: discord removed from tinyclaw default features
     # TODO: Remove once serenity 0.13+ releases with rustls 0.23+ support
     "RUSTSEC-2026-0049",
+    # rand unsound with custom logger + thread_rng - currently transitive via proptest/dev tooling.
+    # TODO: remove once the rand 0.9.3+ upgrade lands across the dependency graph.
+    "RUSTSEC-2026-0097",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- remove the obsolete `cargo audit --fetch` call from `ci-main.yml` and keep the security scan aligned with the installed cargo-audit CLI
- acknowledge `RUSTSEC-2026-0097` in `deny.toml` so `cargo deny check advisories` matches the current dependency graph on main
- update `cross_mode_consistency_test` to parse the current CLI human output format, restoring the main-branch cross-mode tests

## Verification
- cargo deny check advisories
- cargo test -p terraphim_agent --test cross_mode_consistency_test -- --nocapture
- cargo test --release --target x86_64-unknown-linux-gnu -p terraphim_agent --test cross_mode_consistency_test -- --nocapture