### PR TITLE
fix(mcp): pass zlob through nested CI cargo runs

### DIFF
--- a/crates/terraphim_mcp_server/tests/mcp_autocomplete_e2e_test.rs
+++ b/crates/terraphim_mcp_server/tests/mcp_autocomplete_e2e_test.rs
@@ -118,8 +118,13 @@ async fn create_autocomplete_test_config() -> Result<String> {
 /// Start the MCP server as a subprocess and return the transport
 async fn start_mcp_server() -> Result<TokioChildProcess> {
     let mut cmd = Command::new("cargo");
-    cmd.args(["run", "--bin", "terraphim_mcp_server"])
-        .stdin(std::process::Stdio::piped())
+    cmd.arg("run").arg("--bin").arg("terraphim_mcp_server");
+
+    if std::env::var_os("CI").is_some() {
+        cmd.arg("--features").arg("zlob");
+    }
+
+    cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 

--- a/crates/terraphim_mcp_server/tests/test_mcp_fixes_validation.rs
+++ b/crates/terraphim_mcp_server/tests/test_mcp_fixes_validation.rs
@@ -10,12 +10,17 @@ async fn test_mcp_log_separation_and_tools() -> Result<()> {
     println!("🧪 Testing MCP server log separation and tool availability");
 
     // Build the server first
-    let build_status = Command::new("cargo")
+    let mut build = Command::new("cargo");
+    build
         .arg("build")
         .arg("--package")
-        .arg("terraphim_mcp_server")
-        .status()
-        .await?;
+        .arg("terraphim_mcp_server");
+
+    if std::env::var_os("CI").is_some() {
+        build.arg("--features").arg("zlob");
+    }
+
+    let build_status = build.status().await?;
 
     if !build_status.success() {
         anyhow::bail!("Failed to build terraphim_mcp_server");

--- a/crates/terraphim_mcp_server/tests/test_mcp_stdio.rs
+++ b/crates/terraphim_mcp_server/tests/test_mcp_stdio.rs
@@ -22,8 +22,13 @@ fn test_mcp_autocomplete_via_stdio() {
     // Start the MCP server
     // NOTE: Don't pass --verbose here. It can enable non-JSON output on stdout,
     // which breaks stdio JSON-RPC framing.
-    let mut child = Command::new("cargo")
-        .args(["run", "--"])
+    let mut command = Command::new("cargo");
+    command.arg("run");
+    if std::env::var_os("CI").is_some() {
+        command.arg("--features").arg("zlob");
+    }
+    let mut child = command
+        .args(["--"])
         .current_dir(".")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/terraphim_mcp_server/tests/test_tools_list.rs
+++ b/crates/terraphim_mcp_server/tests/test_tools_list.rs
@@ -15,8 +15,13 @@ fn test_tools_list_only() {
     println!("Starting MCP server test for tools list...");
 
     // Start the MCP server
-    let mut child = Command::new("cargo")
-        .args(["run", "--", "--verbose"])
+    let mut command = Command::new("cargo");
+    command.arg("run");
+    if std::env::var_os("CI").is_some() {
+        command.arg("--features").arg("zlob");
+    }
+    let mut child = command
+        .args(["--", "--verbose"])
         .current_dir(".")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary
- propagate `--features zlob` to all nested MCP test harness `cargo run` / `cargo build` invocations when `CI=true`
- cover the remaining MCP test files that were still spawning nested builds without the fff-search feature contract
- remove the last deterministic `CI Main Branch` release-build failures on current `main`

## Verification
- cargo fmt
- CI=true cargo test --release --target x86_64-unknown-linux-gnu -p terraphim_mcp_server --test integration_test --features zlob -- --nocapture
- CI=true cargo test --release --target x86_64-unknown-linux-gnu -p terraphim_mcp_server --test mcp_autocomplete_e2e_test --features zlob -- --nocapture
- CI=true cargo test --release --target x86_64-unknown-linux-gnu -p terraphim_mcp_server --test test_mcp_fixes_validation --features zlob -- --nocapture
- CI=true cargo test --release --target x86_64-unknown-linux-gnu --workspace --features "self_update/signatures,zlob"