### PR TITLE
fix(listener): migrate from chrono to jiff for RFC3339 timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8498,6 +8498,7 @@ dependencies = [
  "futures",
  "glob",
  "insta",
+ "jiff",
  "log",
  "portpicker",
  "pulldown-cmark 0.13.3",

--- a/crates/terraphim_agent/Cargo.toml
+++ b/crates/terraphim_agent/Cargo.toml
@@ -53,6 +53,7 @@ regex = "1.12"
 glob = "0.3"
 async-trait = { workspace = true }
 chrono = { workspace = true }
+jiff = { version = "0.2", features = ["serde"] }
 strsim = "0.11"  # For edit distance / fuzzy matching in forgiving CLI
 uuid = { workspace = true }
 dialoguer = "0.12"  # Interactive CLI prompts for onboarding wizard

--- a/crates/terraphim_agent/src/listener.rs
+++ b/crates/terraphim_agent/src/listener.rs
@@ -485,7 +485,7 @@ mod tests {
         runtime.last_seen_at = "2026-04-04T10:00:00Z".to_string();
         runtime.poll_once().await.unwrap();
 
-        assert_eq!(runtime.last_seen_at, "2026-04-04T11:00:00+00:00");
+        assert_eq!(runtime.last_seen_at, "2026-04-04T11:00:00Z");
         assert!(runtime.seen_events.is_empty());
     }
 
@@ -834,7 +834,7 @@ mod tests {
         let mut runtime = ListenerRuntime::new(config).unwrap();
         runtime.last_seen_at = "2026-04-04T10:00:00Z".to_string();
         runtime.poll_once().await.unwrap();
-        assert_eq!(runtime.last_seen_at, "2026-04-04T12:30:00+00:00");
+        assert_eq!(runtime.last_seen_at, "2026-04-04T12:30:00Z");
     }
 
     #[tokio::test]
@@ -963,7 +963,7 @@ mod tests {
         assert!(runtime.seen_events.is_empty());
 
         runtime.poll_once().await.unwrap();
-        assert_eq!(runtime.last_seen_at, "2026-04-04T12:30:00+00:00");
+        assert_eq!(runtime.last_seen_at, "2026-04-04T12:30:00Z");
         assert_eq!(runtime.seen_events.len(), 1);
     }
 
@@ -1092,7 +1092,7 @@ mod tests {
         assert!(runtime.seen_events.is_empty());
 
         runtime.poll_once().await.unwrap();
-        assert_eq!(runtime.last_seen_at, "2026-04-04T12:30:00+00:00");
+        assert_eq!(runtime.last_seen_at, "2026-04-04T12:30:00Z");
         assert_eq!(runtime.seen_events.len(), 1);
     }
 
@@ -1268,7 +1268,7 @@ impl ListenerRuntime {
             parser,
             accepted_target_names,
             seen_events: std::collections::HashSet::new(),
-            last_seen_at: chrono::Utc::now().to_rfc3339(),
+            last_seen_at: jiff::Timestamp::now().to_string(),
         })
     }
 
@@ -1289,7 +1289,7 @@ impl ListenerRuntime {
 
     pub async fn poll_once(&mut self) -> Result<()> {
         let mut page = 1u32;
-        let mut newest_seen_at: Option<chrono::DateTime<chrono::Utc>> = None;
+        let mut newest_seen_at: Option<jiff::Timestamp> = None;
         let mut should_retry_current_cursor = false;
 
         loop {
@@ -1326,25 +1326,18 @@ impl ListenerRuntime {
 
         if !should_retry_current_cursor {
             if let Some(newest_seen_at) = newest_seen_at {
-                self.last_seen_at = newest_seen_at.to_rfc3339();
+                self.last_seen_at = newest_seen_at.to_string();
             }
         }
         Ok(())
     }
 
-    fn comment_timestamp(
-        comment: &terraphim_tracker::IssueComment,
-    ) -> Option<chrono::DateTime<chrono::Utc>> {
+    fn comment_timestamp(comment: &terraphim_tracker::IssueComment) -> Option<jiff::Timestamp> {
         comment
             .updated_at
-            .parse::<chrono::DateTime<chrono::FixedOffset>>()
-            .or_else(|_| {
-                comment
-                    .created_at
-                    .parse::<chrono::DateTime<chrono::FixedOffset>>()
-            })
+            .parse::<jiff::Timestamp>()
+            .or_else(|_| comment.created_at.parse::<jiff::Timestamp>())
             .ok()
-            .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
     }
 
     fn should_retry_issue_fetch(error: &terraphim_tracker::TrackerError) -> bool {

--- a/plans/design-single-agent-listener.md
+++ b/plans/design-single-agent-listener.md
@@ -1,0 +1,194 @@
+# Design & Implementation Plan: Single Gitea Listener Agent on Local Laptop
+
+## 1. Summary of Target Behaviour
+
+A single `terraphim-agent` process runs in a tmux session, polling `git.terraphim.cloud` for new comments mentioning `@adf:terraphim-worker`. When mentioned, the agent:
+
+1. Fetches the referenced issue
+2. Claims the issue (assigns itself via Gitea API)
+3. Posts an acknowledgement comment on the issue
+4. Tracks processed events in memory to avoid duplicates
+
+The agent runs continuously with a configurable poll interval and retries transient failures automatically.
+
+**No code changes to the Rust codebase are required.** This is purely an operational setup task: build, configure, and launch the existing listener infrastructure.
+
+## 2. Key Invariants and Acceptance Criteria
+
+### Invariants
+| Invariant | Description |
+|-----------|-------------|
+| I1: Single instance | Exactly one listener process running at any time |
+| I2: At-least-once processing | Every mention is processed (duplicates avoided via seen_events set) |
+| I3: No duplicate claims | GiteaTracker checks current assignees before claiming |
+| I4: Token never on disk | GITEA_TOKEN injected via `op run` at session start |
+| I5: Offline-only | No terraphim_server dependency |
+
+### Acceptance Criteria
+| ID | Criterion | Verification |
+|----|-----------|-------------|
+| AC1 | Agent starts and connects to Gitea successfully | tmux shows "listener config has no Gitea connection" absent; poll logs appear |
+| AC2 | Posting `@adf:terraphim-worker` on a Gitea issue triggers a claim | Issue assignee changes to the configured login; ack comment appears |
+| AC3 | Agent ignores its own comments | No self-referencing loops |
+| AC4 | Agent survives transient Gitea errors (500, 429) | Continues polling after error; log shows retry |
+| AC5 | Agent restarts cleanly in tmux | Can kill and restart without side effects |
+| AC6 | Token is never written to disk in plaintext | Config file has no token; only env var |
+
+## 3. High-Level Design and Boundaries
+
+### Architecture
+
+```
+[tmux: terraphim-worker]
+  |
+  +-- op run --no-masking -- terraphim-agent listen --config listener.json
+        |
+        +-- ListenerRuntime (in-memory)
+              |
+              +-- GiteaTracker (REST API client)
+              |     |-- fetch_repo_comments_page()
+              |     |-- claim_issue()
+              |     |-- post_comment()
+              |
+              +-- AdfCommandParser (@adf: parsing)
+              |
+              +-- control_plane::normalize_polled_command()
+```
+
+### Boundaries
+- **No changes to Rust source code** -- pure operational setup
+- **No terraphim_server** -- listener is offline-only
+- **No LLM provider** -- agent claims and acknowledges only, does not implement work
+- **No gitea-robot** -- using `ApiOnly` claim strategy (binary not present at hardcoded path)
+
+## 4. File/Module-Level Change Plan
+
+| File/Module | Action | Before | After |
+|-------------|--------|--------|-------|
+| `~/.config/terraphim/listener-worker.json` | Create | N/A | Listener config for terraphim-worker identity |
+| `~/.config/terraphim/scripts/start-listener.sh` | Create | N/A | tmux launch script with op token injection |
+| `~/.cargo/bin/terraphim-agent` | Rebuild | Current installed binary | Latest from source (includes listener fixes) |
+
+### listener-worker.json contents:
+```json
+{
+  "identity": {
+    "agent_name": "terraphim-worker",
+    "gitea_login": "<GITEA_LOGIN>"
+  },
+  "gitea": {
+    "base_url": "https://git.terraphim.cloud",
+    "owner": "terraphim",
+    "repo": "terraphim-ai"
+  },
+  "claim_strategy": "api_only",
+  "poll_interval_secs": 30,
+  "notification_rules": [],
+  "delegation": {
+    "allowed_specialists": [],
+    "exclusive_assignment": true,
+    "max_fanout_depth": 1
+  },
+  "repo_scope": "terraphim/terraphim-ai"
+}
+```
+
+### start-listener.sh outline:
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+source ~/.profile
+export GITEA_URL="https://git.terraphim.cloud"
+export GITEA_TOKEN=$(op read "op://TerraphimPlatform/gitea-test-token/credential")
+tmux new-session -d -s terraphim-worker \
+  "~/.cargo/bin/terraphim-agent listen --config ~/.config/terraphim/listener-worker.json"
+tmux attach -t terraphim-worker
+```
+
+## 5. Step-by-Step Implementation Sequence
+
+### Step 1: Build release binary from source
+- **Purpose**: Include latest listener fixes (retry logic, paging, claim verification)
+- **Command**: `cargo build -p terraphim_agent --release --features repl-full`
+- **Deployable**: Yes (binary upgrade, listener not yet running)
+- **Verify**: `target/release/terraphim-agent --version`
+
+### Step 2: Copy binary to cargo bin
+- **Purpose**: Make latest binary available at expected path
+- **Command**: `cp target/release/terraphim-agent ~/.cargo/bin/terraphim-agent`
+- **Deployable**: Yes
+
+### Step 3: Create listener config file
+- **Purpose**: Static JSON config for the agent identity
+- **Action**: Write `~/.config/terraphim/listener-worker.json`
+- **Requires**: Gitea login name from user
+- **Verify**: `terraphim-agent listen --identity terraphim-worker` (dry run with no Gitea)
+
+### Step 4: Create launch script
+- **Purpose**: Reproducible tmux session startup with 1Password token injection
+- **Action**: Write `~/.config/terraphim/scripts/start-listener.sh`, chmod +x
+- **Verify**: Script passes shellcheck
+
+### Step 5: Test dry run (no Gitea connection)
+- **Purpose**: Verify config loads and validates correctly
+- **Command**: `GITEA_TOKEN=test terraphim-agent listen --config ~/.config/terraphim/listener-worker.json`
+- **Expected**: Prints identity info, "listener config has no Gitea connection" only if gitea block missing; otherwise starts polling
+- **Verify**: Ctrl+C to stop
+
+### Step 6: Launch in tmux with real token
+- **Purpose**: Start the agent in production mode
+- **Action**: Run start-listener.sh
+- **Verify**: `tmux attach -t terraphim-worker` shows poll logs
+
+### Step 7: End-to-end validation
+- **Purpose**: Confirm agent claims issues when mentioned
+- **Action**: Post a test comment on a Gitea issue with `@adf:terraphim-worker`
+- **Verify**: Agent claims issue, posts ack comment, tmux logs show the event
+
+### Step 8: Document and hand off
+- **Purpose**: Record setup for future sessions
+- **Action**: Update HANDOVER.md or create a brief note in `.docs/`
+- **Verify**: Next session can restart agent with single command
+
+## 6. Testing & Verification Strategy
+
+| Acceptance Criterion | Test Type | Verification Method |
+|---------------------|-----------|---------------------|
+| AC1: Agent connects | Integration | Check tmux logs for successful poll cycle |
+| AC2: Mention triggers claim | E2E | Post test comment, check issue assignee and ack comment |
+| AC3: Ignores own comments | Unit (existing) | Already tested in listener.rs:442 (listener_runtime_ignores_self_authored_comments) |
+| AC4: Survives transient errors | Unit (existing) | Already tested in listener.rs:970 (retry transient failures) |
+| AC5: Restarts cleanly | Manual | Kill tmux session, re-run start script, verify clean start |
+| AC6: Token not on disk | Manual | Grep listener-worker.json for token-like strings; check env only |
+
+### Existing test coverage (no new tests needed):
+- `listener.rs` contains 12 comprehensive unit/integration tests covering:
+  - Config validation
+  - Claim and ack flow
+  - Self-authored comment filtering
+  - Pagination
+  - Transient error retry
+  - Handoff to specialists
+  - Agent name aliasing
+
+## 7. Risk & Complexity Review
+
+| Risk | Likelihood | Mitigation | Residual |
+|------|-----------|------------|----------|
+| Token lacks issue-assign permission | Medium | Test claim on a real issue before relying on agent | May need to adjust token scope in Gitea |
+| gitea-robot path hardcoded but missing | N/A | Using `ApiOnly` strategy (no robot dependency) | None |
+| Agent crashes and loses seen_events | Low | Acceptable for initial setup; events reprocessed on restart | May see duplicate ack comments on restart |
+| Poll interval too aggressive for Gitea | Low | 30s default is conservative; Gitea rate limits are generous | Could increase to 60s if needed |
+| Binary rebuild takes time | Low | Release build ~2-5 min on 16-core machine | None |
+
+### Complexity assessment: **LOW**
+- No code changes required
+- No new dependencies
+- Purely operational/configuration task
+- Existing test coverage is comprehensive
+
+## 8. Open Questions / Decisions for Human Review
+
+1. **Gitea login name**: What is your login name on `git.terraphim.cloud`? This goes in the `gitea_login` field so the agent can post comments and claim issues as you.
+2. **Poll interval**: Is 30 seconds acceptable, or would you prefer a different interval?
+3. **Auto-start on boot**: Should the tmux session be launched automatically (e.g., via a systemd user service or crontab @reboot), or is manual start sufficient?

--- a/plans/research-single-agent-listener.md
+++ b/plans/research-single-agent-listener.md
@@ -1,0 +1,155 @@
+# Research Document: Spin Single Gitea Listener Agent on Local Laptop
+
+## 1. Problem Restatement and Scope
+
+**Problem**: Run a single terraphim-agent in listener mode on this laptop to poll Gitea issues, claim assigned work, and acknowledge mentions. The agent should run in a tmux session for persistence.
+
+**IN Scope**:
+- Configure and run `terraphim-agent listen --identity NAME` connected to `git.terraphim.cloud`
+- Agent claims issues when mentioned via `@adf:<agent-name>` in Gitea comments
+- Agent posts acknowledgement comments back to Gitea
+- Run as a long-lived tmux session
+- Use CLI-based tooling (no LLM routing required for the listener itself)
+- Agent can delegate to specialists via handoff mechanism
+
+**OUT of Scope**:
+- Full autonomous task execution (implementing code, running tests, creating PRs)
+- LLM integration for code generation
+- Multi-agent orchestration or fleet management
+- Symphony/orchestrator binary (separate build)
+- Server mode (TUI/fullscreen)
+
+## 2. User and Business Outcomes
+
+- **User-visible**: A running agent that watches Gitea for mentions and claims issues automatically
+- **Business value**: Reduces manual issue triage; agent acts as a persistent "always-on" worker
+- **Observable outcomes**:
+  - Gitea issues get claimed automatically when `@adf:<name>` is used in comments
+  - Acknowledgement comments appear on claimed issues
+  - tmux session shows listener poll logs
+
+## 3. System Elements and Dependencies
+
+### 3.1 terraphim-agent binary
+- **Location**: `~/.cargo/bin/terraphim-agent` (already installed)
+- **Role**: CLI entry point with `listen` subcommand
+- **Key files**:
+  - `crates/terraphim_agent/src/main.rs` - CLI dispatch, listen command at line 1059
+  - `crates/terraphim_agent/src/listener.rs` - ListenerConfig, ListenerRuntime, run_listener
+- **Dependencies**: tokio runtime, terraphim_tracker, terraphim_orchestrator (ADF parser)
+
+### 3.2 ListenerConfig (JSON)
+- **Location**: Passed via `--config PATH` or constructed from `--identity NAME`
+- **Structure** (listener.rs:97-111):
+  ```json
+  {
+    "identity": { "agent_name": "NAME", "gitea_login": "LOGIN" },
+    "gitea": { "base_url": "https://git.terraphim.cloud", "owner": "terraphim", "repo": "terraphim-ai" },
+    "claim_strategy": "prefer_robot",
+    "poll_interval_secs": 30,
+    "notification_rules": [],
+    "delegation": { "allowed_specialists": [], "exclusive_assignment": true, "max_fanout_depth": 1 },
+    "repo_scope": "terraphim/terraphim-ai"
+  }
+  ```
+- **Token**: Read from `identity.token_path` file, `gitea.token_path` file, or `GITEA_TOKEN` env var
+
+### 3.3 GiteaTracker (terraphim_tracker)
+- **Location**: `crates/terraphim_tracker/src/gitea.rs`
+- **Role**: API client for Gitea REST API (issues, comments, assignments)
+- **Hardcoded path**: `robot_path: PathBuf::from("/home/alex/go/bin/gitea-robot")` at listener.rs:1252
+
+### 3.4 AdfCommandParser (terraphim_orchestrator)
+- **Location**: `crates/terraphim_orchestrator/src/adf_commands.rs`
+- **Role**: Parses `@adf:<agent-name>` mentions from comment bodies
+
+### 3.5 Gitea at git.terraphim.cloud
+- **Role**: Single source of truth for issues, comments, assignments
+- **Auth**: API token required (currently not in env - needs setup)
+
+### 3.6 tmux
+- **Role**: Persistent session for long-running listener process
+- **Pattern**: Already established in AGENTS.md for background tasks
+
+### 3.7 Existing config
+- **Settings**: `~/.config/terraphim/settings.toml` (exists, configured for local dev)
+- **Data**: `~/.terraphim/` (exists with config.json, default_thesaurus.json, sqlite)
+- **No KG dir**: `~/.config/terraphim/kg/` does not exist (listener does not need KG)
+
+## 4. Constraints and Their Implications
+
+### 4.1 Gitea authentication
+- **Constraint**: `GITEA_TOKEN` env var must be set OR `token_path` must point to a file containing the token
+- **Why it matters**: Listener will fail to start without a valid token
+- **Current state**: Neither `GITEA_URL` nor `GITEA_TOKEN` are set in the current shell (checked)
+- **Resolution**: Use `op read "op://TerraphimPlatform/gitea-test-token/credential"` from 1Password (as per CLAUDE.md)
+
+### 4.2 Robot path hardcoded
+- **Constraint**: `gitea-robot` binary path is hardcoded to `/home/alex/go/bin/gitea-robot` at listener.rs:1252
+- **Implication**: Must exist at that path when `claim_strategy: prefer_robot` is used
+- **Status**: Needs verification that the binary exists
+
+### 4.3 Claim strategy
+- **Options**: `ApiOnly`, `PreferRobot`, `RobotOnly`
+- **Implication**: `PreferRobot` tries gitea-robot first, falls back to API. `ApiOnly` uses REST API directly.
+- **Recommendation**: `ApiOnly` is simplest for initial setup (avoids gitea-robot dependency)
+
+### 4.4 Offline-only mode
+- **Constraint**: Listen command rejects `--server` flag (main.rs:1061)
+- **Implication**: No terraphim_server needed; listener is fully self-contained
+
+### 4.5 No persistence across restarts
+- **Constraint**: `seen_events` and `last_seen_at` are in-memory (listener.rs:1270-1271)
+- **Implication**: On restart, agent re-processes all comments since `chrono::Utc::now()` (only new ones)
+- **Risk**: If agent crashes and restarts, it may miss comments during downtime
+
+### 4.6 System resources
+- **Available**: 62 GiB RAM, 16 cores, x86_64 Linux
+- **Implication**: More than sufficient for a single listener process
+
+## 5. Risks, Unknowns, and Assumptions
+
+### UNKNOWNS
+1. **Gitea token permissions**: Does the token in 1Password have sufficient permissions for issue assignment and comment posting?
+2. **Gitea user account**: What login name should the agent use on Gitea? Is there a dedicated agent account?
+3. **gitea-robot binary**: Does `/home/alex/go/bin/gitea-robot` exist and work?
+
+### ASSUMPTIONS
+1. The Gitea instance at `git.terraphim.cloud` is reachable from this laptop
+2. A valid Gitea API token exists in 1Password at the expected path
+3. The terraphim-agent binary is current (may need rebuild from source)
+4. The agent does not need to execute any work -- only claim and acknowledge
+
+### RISKS
+1. **Token expiry**: Gitea token may expire, requiring re-injection. De-risk: check token validity before starting.
+2. **Network connectivity**: Laptop may lose connection to Gitea. Mitigation: listener already has retry logic for transient errors (listener.rs:1350-1378).
+3. **Binary version mismatch**: Installed binary may not include latest listener fixes (commit 21dc532c, 3efe03c8, 7aa18ec4). De-risk: rebuild from source.
+4. **Duplicate processing**: Multiple listener instances with same identity could race on claims. Mitigation: GiteaTracker checks current assignees before claiming.
+
+## 6. Context Complexity vs. Simplicity Opportunities
+
+### Sources of Complexity
+1. Token management spans env vars, file paths, and 1Password
+2. Hardcoded robot path couples listener to specific machine layout
+3. Multiple claim strategies add branching logic
+
+### Simplification Strategies
+1. **Minimal config**: Use `ApiOnly` claim strategy to avoid gitea-robot dependency
+2. **Env var token**: Set `GITEA_TOKEN` in the tmux session startup script (from `op read`)
+3. **Single JSON config file**: Write a static config once, reference with `--config`
+4. **Start small, iterate**: Get listener running and claiming before adding delegation
+
+### Proposed Minimal Setup
+1. Write listener JSON config
+2. Export `GITEA_TOKEN` from 1Password
+3. Build latest binary from source (to include recent fixes)
+4. Start in tmux with: `terraphim-agent listen --config listener.json`
+5. Test by mentioning the agent in a Gitea issue comment
+
+## 7. Questions for Human Reviewer
+
+1. **Agent identity name**: What should the agent_name be (e.g., "alex-agent", "terraphim-worker")?
+2. **Gitea login**: What is your Gitea login name at git.terraphim.cloud? Should the agent use your account or a dedicated bot account?
+3. **Repo scope**: Should the agent watch only `terraphim/terraphim-ai` or multiple repos?
+4. **Rebuild binary**: Should I rebuild terraphim-agent from source to include the latest listener fixes, or use the installed binary?
+5. **Delegation**: Should the agent be allowed to delegate to any specialists, or should delegation be disabled initially?


### PR DESCRIPTION
## Summary

- Migrate listener timestamps from `chrono` to `jiff` to fix 422 errors when polling Gitea
- Chrono's `to_rfc3339()` produces nanosecond-precision timestamps (e.g. `2026-04-14T08:50:07.850217361+00:00`) that Gitea cannot parse
- Jiff's `Timestamp::to_string()` produces clean RFC3339 without nanoseconds (e.g. `2026-04-14T08:50:07Z`)
- Includes research and design documents for single agent listener deployment

## Changes

- `listener.rs`: Replace all `chrono` usage with `jiff::Timestamp` for timestamp handling
- `Cargo.toml`: Add `jiff = "0.2"` dependency (already used across workspace)
- Updated test assertions to match `Z` suffix instead of `+00:00`

## Test plan

- [x] All 17 listener tests pass
- [x] E2E validated: agent claims Gitea issues and posts ack comments
- [x] Pre-commit checks pass (fmt, clippy, build, tests)