### PR TITLE
feat(markdown-parser): upstream MatchStrategy, iterative normalize, configurable SectionConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8437,6 +8437,7 @@ name = "terraphim-markdown-parser"
 version = "1.0.0"
 dependencies = [
  "markdown",
+ "serde",
  "terraphim_types",
  "thiserror 1.0.69",
  "ulid",

--- a/crates/terraphim-markdown-parser/Cargo.toml
+++ b/crates/terraphim-markdown-parser/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../../README.md"
 
 [dependencies]
 markdown = "1.0.0-alpha.21"
+serde = { workspace = true }
 terraphim_types = { path = "../terraphim_types", version = "1.0.0" }
 thiserror = { workspace = true }
 

--- a/crates/terraphim-markdown-parser/src/heading.rs
+++ b/crates/terraphim-markdown-parser/src/heading.rs
@@ -1,11 +1,21 @@
 use std::ops::Range;
 
 use markdown::mdast::Node;
+use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
 use crate::{MarkdownParserError, NormalizedMarkdown, children, collect_text_content};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Strategy used to match a heading title against a `SectionPattern`'s pattern string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MatchStrategy {
+    /// Match when the heading title starts with the pattern.
+    Prefix,
+    /// Match when the heading title contains the pattern anywhere.
+    Contains,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SectionType {
     Main,
     Sidebar(String),
@@ -24,13 +34,14 @@ impl std::fmt::Display for SectionType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SectionPattern {
-    pub prefix: String,
+    pub pattern: String,
     pub section_type: SectionType,
+    pub match_strategy: MatchStrategy,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SectionConfig {
     pub rules: Vec<SectionPattern>,
 }
@@ -40,28 +51,36 @@ impl SectionConfig {
         Self {
             rules: vec![
                 SectionPattern {
-                    prefix: "Power Selling".to_string(),
+                    pattern: "Power Selling".to_string(),
                     section_type: SectionType::Sidebar("PowerSelling".to_string()),
+                    match_strategy: MatchStrategy::Prefix,
                 },
                 SectionPattern {
-                    prefix: "Power Player".to_string(),
+                    pattern: "Power Player".to_string(),
                     section_type: SectionType::Sidebar("PowerPlayer".to_string()),
+                    match_strategy: MatchStrategy::Prefix,
                 },
                 SectionPattern {
-                    prefix: "Power Point".to_string(),
+                    pattern: "Power Point".to_string(),
                     section_type: SectionType::Sidebar("PowerPoint".to_string()),
+                    match_strategy: MatchStrategy::Prefix,
                 },
+                // "Selling U" uses Contains because the phrase can appear
+                // mid-title (e.g. "Chapter 3: Selling U -- Your Career").
                 SectionPattern {
-                    prefix: "Selling U".to_string(),
+                    pattern: "Selling U".to_string(),
                     section_type: SectionType::Career,
+                    match_strategy: MatchStrategy::Contains,
                 },
                 SectionPattern {
-                    prefix: "Key Takeaways".to_string(),
+                    pattern: "Key Takeaways".to_string(),
                     section_type: SectionType::Assessment,
+                    match_strategy: MatchStrategy::Prefix,
                 },
                 SectionPattern {
-                    prefix: "Test Your Power Knowledge".to_string(),
+                    pattern: "Test Your Power Knowledge".to_string(),
                     section_type: SectionType::Assessment,
+                    match_strategy: MatchStrategy::Prefix,
                 },
             ],
         }
@@ -70,7 +89,11 @@ impl SectionConfig {
     pub fn classify(&self, title: &str) -> SectionType {
         let title_trimmed = title.trim();
         for rule in &self.rules {
-            if title_trimmed.starts_with(&rule.prefix) {
+            let matched = match rule.match_strategy {
+                MatchStrategy::Prefix => title_trimmed.starts_with(&rule.pattern),
+                MatchStrategy::Contains => title_trimmed.contains(&rule.pattern),
+            };
+            if matched {
                 return rule.section_type.clone();
             }
         }
@@ -328,14 +351,35 @@ mod tests {
     fn custom_section_config() {
         let config = SectionConfig {
             rules: vec![SectionPattern {
-                prefix: "Experiment".to_string(),
+                pattern: "Experiment".to_string(),
                 section_type: SectionType::Sidebar("Lab".to_string()),
+                match_strategy: MatchStrategy::Prefix,
             }],
         };
         assert_eq!(
             config.classify("Experiment 3: Results"),
             SectionType::Sidebar("Lab".to_string())
         );
+        assert_eq!(config.classify("Introduction"), SectionType::Main);
+    }
+
+    #[test]
+    fn match_strategy_contains() {
+        let config = SectionConfig {
+            rules: vec![SectionPattern {
+                pattern: "Selling U".to_string(),
+                section_type: SectionType::Career,
+                match_strategy: MatchStrategy::Contains,
+            }],
+        };
+        // Contains matches mid-title
+        assert_eq!(
+            config.classify("Chapter 3: Selling U -- Your Career"),
+            SectionType::Career,
+        );
+        // Contains also matches at the start
+        assert_eq!(config.classify("Selling U: Careers"), SectionType::Career,);
+        // No match when substring is absent
         assert_eq!(config.classify("Introduction"), SectionType::Main);
     }
 }

--- a/crates/terraphim-markdown-parser/src/lib.rs
+++ b/crates/terraphim-markdown-parser/src/lib.rs
@@ -13,7 +13,8 @@ pub mod heading;
 
 pub use chunk::{ContentChunk, chunk_by_headings};
 pub use heading::{
-    HeadingNode, HeadingTree, SectionConfig, SectionType, build_heading_tree, classify_sections,
+    HeadingNode, HeadingTree, MatchStrategy, SectionConfig, SectionPattern, SectionType,
+    build_heading_tree, classify_sections,
 };
 
 pub const TERRAPHIM_BLOCK_ID_PREFIX: &str = "terraphim:block-id:";
@@ -48,7 +49,7 @@ fn find_first_h1(node: &Node) -> Option<String> {
 }
 
 /// Recursively collect all text content from AST nodes.
-fn collect_text_content(nodes: &[Node]) -> String {
+pub(crate) fn collect_text_content(nodes: &[Node]) -> String {
     let mut text = String::new();
     for node in nodes {
         match node {
@@ -149,12 +150,24 @@ pub fn ensure_terraphim_block_ids(markdown: &str) -> Result<String, MarkdownPars
 }
 
 /// Normalize markdown into canonical Terraphim form and return the extracted blocks.
+///
+/// Uses an iterative fixed-point loop (up to 4 passes) because inserting inline
+/// block IDs into list items can change how the markdown crate re-parses the
+/// result, exposing adjacent paragraphs as root-level paragraphs without block
+/// IDs. Repeating until the output stabilizes ensures every block is tagged.
 pub fn normalize_markdown(markdown: &str) -> Result<NormalizedMarkdown, MarkdownParserError> {
-    let normalized = ensure_terraphim_block_ids(markdown)?;
-    let blocks = extract_blocks(&normalized)?;
-    let ast = markdown::to_mdast(&normalized, &ParseOptions::gfm()).ok();
+    let mut current = ensure_terraphim_block_ids(markdown)?;
+    for _ in 0..4 {
+        let next = ensure_terraphim_block_ids(&current)?;
+        if next == current {
+            break;
+        }
+        current = next;
+    }
+    let blocks = extract_blocks(&current)?;
+    let ast = markdown::to_mdast(&current, &ParseOptions::gfm()).ok();
     Ok(NormalizedMarkdown {
-        markdown: normalized,
+        markdown: current,
         blocks,
         ast,
     })
@@ -640,6 +653,43 @@ mod tests {
         assert_eq!(
             extract_first_heading(input),
             Some("The bun Runtime".to_string())
+        );
+    }
+
+    #[test]
+    fn iterative_normalization_stabilizes() {
+        // After inserting inline block IDs into list items, the markdown parser
+        // may re-parse the result differently, exposing adjacent text as a new
+        // paragraph without a block ID. The iterative loop must handle this.
+        //
+        // This input has a list item immediately followed by a paragraph with
+        // no blank line separating them, which can trigger re-parsing shifts.
+        let input = "- item one\n- item two\n\nA paragraph after the list.\n\nAnother paragraph.\n";
+
+        // Single pass
+        let pass1 = ensure_terraphim_block_ids(input).unwrap();
+
+        // The iterative normalize_markdown must produce a stable result
+        let normalized = normalize_markdown(input).unwrap();
+
+        // Verify stability: running ensure_terraphim_block_ids again should
+        // produce the same output (the fixed-point was reached).
+        let again = ensure_terraphim_block_ids(&normalized.markdown).unwrap();
+        assert_eq!(
+            again, normalized.markdown,
+            "normalization should be stable after normalize_markdown"
+        );
+
+        // All blocks must have IDs: 2 list items + 2 paragraphs = 4
+        let id_count = normalized
+            .markdown
+            .lines()
+            .filter(|l| l.contains("<!-- terraphim:block-id:"))
+            .count();
+        assert!(
+            id_count >= 4,
+            "expected at least 4 block IDs, got {id_count}; pass1 had {} IDs",
+            count_block_ids(&pass1),
         );
     }
 }


### PR DESCRIPTION
## Summary

- Upstream generic improvements from the `zestic-ai/odilo` fork of `terraphim-markdown-parser`
- Add `MatchStrategy` enum (Prefix/Contains) for flexible section classification
- Replace single-pass `normalize_markdown` with iterative fixed-point loop (max 5 passes) to handle block-ID insertion instability
- Add serde derives to `SectionConfig`, `SectionPattern`, `SectionType`, `MatchStrategy` for external configurability
- Change `collect_text_content` to `pub(crate)` for cross-module access

## Test plan

- [x] 26 tests pass (24 existing + 2 new)
- [x] `cargo clippy -p terraphim-markdown-parser` clean
- [x] `cargo fmt` clean
- [ ] CI green

Refs #575