### PR TITLE
feat(listener): shell dispatch bridge -- execute subcommands from @adf mentions

### DIFF
--- a/crates/terraphim_agent/src/listener.rs
+++ b/crates/terraphim_agent/src/listener.rs
@@ -1323,6 +1323,7 @@ impl ListenerRuntime {
                 timeout: std::time::Duration::from_secs(d.timeout_secs),
                 extra_allowed: d.extra_allowed_subcommands.clone(),
                 working_dir: d.working_dir.clone(),
+                guard: std::sync::Arc::new(crate::guard_patterns::CommandGuard::new()),
             }
         });
 

--- a/crates/terraphim_agent/src/listener.rs
+++ b/crates/terraphim_agent/src/listener.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use crate::shell_dispatch;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentIdentity {
@@ -84,6 +86,41 @@ impl Default for DelegationPolicy {
     }
 }
 
+/// Configuration for the shell dispatch bridge.
+///
+/// When present in `ListenerConfig`, enables executing terraphim-agent
+/// subcommands from `@adf:` mention context and posting results back
+/// as Gitea comments.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DispatchConfig {
+    /// Path to the terraphim-agent binary. Defaults to the current executable.
+    #[serde(default)]
+    pub agent_binary: Option<PathBuf>,
+    /// Execution timeout in seconds. Defaults to 300 (5 minutes).
+    #[serde(default = "default_dispatch_timeout")]
+    pub timeout_secs: u64,
+    /// Maximum bytes to capture from stdout+stderr. Defaults to 48000.
+    #[serde(default = "default_max_output_bytes")]
+    pub max_output_bytes: usize,
+    /// Extra subcommands to allow beyond the built-in allowlist.
+    #[serde(default)]
+    pub extra_allowed_subcommands: Vec<String>,
+    /// Working directory for the spawned process.
+    #[serde(default)]
+    pub working_dir: Option<PathBuf>,
+    /// Map subcommand -> specialist agent name for delegation routing.
+    #[serde(default)]
+    pub specialist_routes: HashMap<String, String>,
+}
+
+fn default_dispatch_timeout() -> u64 {
+    300
+}
+
+fn default_max_output_bytes() -> usize {
+    48_000
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GiteaConnection {
     pub base_url: String,
@@ -108,6 +145,10 @@ pub struct ListenerConfig {
     pub delegation: DelegationPolicy,
     #[serde(default)]
     pub repo_scope: Option<String>,
+    /// Shell dispatch configuration. When present, enables executing
+    /// terraphim-agent subcommands from @adf: mention context.
+    #[serde(default)]
+    pub dispatch: Option<DispatchConfig>,
 }
 
 fn default_poll_interval_secs() -> u64 {
@@ -128,6 +169,7 @@ impl ListenerConfig {
                 max_fanout_depth: 1,
             },
             repo_scope: None,
+            dispatch: None,
         }
     }
 
@@ -433,6 +475,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         let mut runtime = ListenerRuntime::new(config).unwrap();
@@ -479,6 +522,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         let mut runtime = ListenerRuntime::new(config).unwrap();
@@ -593,6 +637,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         let mut runtime = ListenerRuntime::new(config).unwrap();
@@ -655,6 +700,7 @@ mod tests {
                 max_fanout_depth: 1,
             },
             repo_scope: None,
+            dispatch: None,
         };
 
         let runtime = ListenerRuntime::new(config).unwrap();
@@ -693,6 +739,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         assert!(ListenerRuntime::new(config).is_ok());
@@ -829,6 +876,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         let mut runtime = ListenerRuntime::new(config).unwrap();
@@ -953,6 +1001,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         let mut runtime = ListenerRuntime::new(config).unwrap();
@@ -1082,6 +1131,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         let mut runtime = ListenerRuntime::new(config).unwrap();
@@ -1188,6 +1238,7 @@ mod tests {
             notification_rules: vec![],
             delegation: DelegationPolicy::default(),
             repo_scope: None,
+            dispatch: None,
         };
 
         let mut runtime = ListenerRuntime::new(config).unwrap();
@@ -1214,6 +1265,7 @@ pub struct ListenerRuntime {
     repo_full_name: String,
     seen_events: std::collections::HashSet<String>,
     last_seen_at: String,
+    dispatch_config: Option<shell_dispatch::ShellDispatchConfig>,
 }
 
 impl ListenerRuntime {
@@ -1261,6 +1313,19 @@ impl ListenerRuntime {
         let agent_names = accepted_target_names.iter().cloned().collect::<Vec<_>>();
         let parser = terraphim_orchestrator::adf_commands::AdfCommandParser::new(&agent_names, &[]);
 
+        let dispatch_config = config.dispatch.as_ref().map(|d| {
+            let agent_binary = d.agent_binary.clone().unwrap_or_else(|| {
+                std::env::current_exe().unwrap_or_else(|_| PathBuf::from("terraphim-agent"))
+            });
+            shell_dispatch::ShellDispatchConfig {
+                agent_binary,
+                max_output_bytes: d.max_output_bytes,
+                timeout: std::time::Duration::from_secs(d.timeout_secs),
+                extra_allowed: d.extra_allowed_subcommands.clone(),
+                working_dir: d.working_dir.clone(),
+            }
+        });
+
         Ok(Self {
             repo_full_name: format!("{}/{}", gitea.owner, gitea.repo),
             config,
@@ -1269,6 +1334,7 @@ impl ListenerRuntime {
             accepted_target_names,
             seen_events: std::collections::HashSet::new(),
             last_seen_at: jiff::Timestamp::now().to_string(),
+            dispatch_config,
         })
     }
 
@@ -1474,6 +1540,103 @@ impl ListenerRuntime {
                         event.event_id,
                     );
                     let _ = self.tracker.post_comment(event.issue_number, &ack).await;
+
+                    // Shell dispatch: parse context and execute subcommand
+                    if let Some(ref dispatch_cfg) = self.dispatch_config {
+                        let extra_allowed = self
+                            .config
+                            .dispatch
+                            .as_ref()
+                            .map(|d| d.extra_allowed_subcommands.clone())
+                            .unwrap_or_default();
+
+                        match shell_dispatch::parse_dispatch_command(&event.context, &extra_allowed)
+                        {
+                            Ok(Some((subcommand, args))) => {
+                                // Check specialist routing
+                                let specialist = self
+                                    .config
+                                    .dispatch
+                                    .as_ref()
+                                    .and_then(|d| d.specialist_routes.get(&subcommand));
+
+                                if let Some(specialist_name) = specialist {
+                                    if self
+                                        .config
+                                        .delegation
+                                        .allowed_specialists
+                                        .contains(specialist_name)
+                                    {
+                                        let note = format!(
+                                            "Routing `{}` to specialist `{}`",
+                                            subcommand, specialist_name
+                                        );
+                                        let _ = self
+                                            .handoff_issue_with_context(
+                                                event.issue_number,
+                                                specialist_name,
+                                                &note,
+                                                Some(&event.session_id),
+                                                Some(&event.event_id),
+                                            )
+                                            .await;
+                                    } else {
+                                        let msg = format!(
+                                            "Cannot route `{}` to `{}`: not in allowed_specialists\n\nsession={} event={}",
+                                            subcommand,
+                                            specialist_name,
+                                            event.session_id,
+                                            event.event_id
+                                        );
+                                        let _ = self
+                                            .tracker
+                                            .post_comment(event.issue_number, &msg)
+                                            .await;
+                                    }
+                                } else {
+                                    // Execute locally
+                                    match shell_dispatch::execute_dispatch(
+                                        dispatch_cfg,
+                                        &subcommand,
+                                        &args,
+                                    )
+                                    .await
+                                    {
+                                        Ok(result) => {
+                                            let reply = shell_dispatch::format_dispatch_result(
+                                                &result,
+                                                &event.target_agent_name,
+                                                &event.session_id,
+                                                &event.event_id,
+                                            );
+                                            let _ = self
+                                                .tracker
+                                                .post_comment(event.issue_number, &reply)
+                                                .await;
+                                        }
+                                        Err(e) => {
+                                            let msg = format!(
+                                                "Dispatch failed for `{}`: {}\n\nsession={} event={}",
+                                                subcommand, e, event.session_id, event.event_id
+                                            );
+                                            let _ = self
+                                                .tracker
+                                                .post_comment(event.issue_number, &msg)
+                                                .await;
+                                        }
+                                    }
+                                }
+                            }
+                            Ok(None) => { /* empty context, claim-only -- no dispatch */ }
+                            Err(e) => {
+                                let msg = format!(
+                                    "Invalid command: {}\n\nsession={} event={}",
+                                    e, event.session_id, event.event_id
+                                );
+                                let _ = self.tracker.post_comment(event.issue_number, &msg).await;
+                            }
+                        }
+                    }
                 }
                 terraphim_tracker::gitea::ClaimResult::AssignedToOther { assignee } => {
                     self.seen_events.insert(event.event_id.clone());

--- a/crates/terraphim_agent/src/main.rs
+++ b/crates/terraphim_agent/src/main.rs
@@ -30,6 +30,7 @@ mod guard_patterns;
 mod listener;
 mod onboarding;
 mod service;
+#[allow(dead_code)]
 mod shell_dispatch;
 
 // Robot mode and forgiving CLI - always available

--- a/crates/terraphim_agent/src/main.rs
+++ b/crates/terraphim_agent/src/main.rs
@@ -30,6 +30,7 @@ mod guard_patterns;
 mod listener;
 mod onboarding;
 mod service;
+mod shell_dispatch;
 
 // Robot mode and forgiving CLI - always available
 mod forgiving;

--- a/crates/terraphim_agent/src/shell_dispatch.rs
+++ b/crates/terraphim_agent/src/shell_dispatch.rs
@@ -14,13 +14,13 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 /// Maximum bytes captured from stdout+stderr before truncation.
-pub const MAX_OUTPUT_BYTES: usize = 48_000;
+pub(crate) const MAX_OUTPUT_BYTES: usize = 48_000;
 
 /// Default execution timeout in seconds.
-pub const DISPATCH_TIMEOUT_SECS: u64 = 300;
+pub(crate) const DISPATCH_TIMEOUT_SECS: u64 = 300;
 
 /// Subcommands that are safe to execute from an @adf mention.
-pub const ALLOWED_SUBCOMMANDS: &[&str] = &[
+pub(crate) const ALLOWED_SUBCOMMANDS: &[&str] = &[
     "search",
     "extract",
     "replace",
@@ -39,7 +39,7 @@ pub const ALLOWED_SUBCOMMANDS: &[&str] = &[
 
 /// Subcommands explicitly denied to prevent recursion, side effects, or
 /// interactive modes.
-pub const DENIED_SUBCOMMANDS: &[&str] = &[
+pub(crate) const DENIED_SUBCOMMANDS: &[&str] = &[
     "listen",
     "repl",
     "interactive",
@@ -53,24 +53,24 @@ const SHELL_METACHARS: &[char] = &['|', ';', '&', '`', '$', '(', ')', '<', '>'];
 
 /// Configuration for the shell dispatch bridge.
 #[derive(Debug, Clone)]
-pub struct ShellDispatchConfig {
-    pub agent_binary: PathBuf,
-    pub max_output_bytes: usize,
-    pub timeout: Duration,
-    pub extra_allowed: Vec<String>,
-    pub working_dir: Option<PathBuf>,
+pub(crate) struct ShellDispatchConfig {
+    pub(crate) agent_binary: PathBuf,
+    pub(crate) max_output_bytes: usize,
+    pub(crate) timeout: Duration,
+    pub(crate) extra_allowed: Vec<String>,
+    pub(crate) working_dir: Option<PathBuf>,
 }
 
 /// Result of executing a dispatched subcommand.
 #[derive(Debug)]
-pub struct DispatchResult {
-    pub subcommand: String,
-    pub exit_code: i32,
-    pub stdout: String,
-    pub stderr: String,
-    pub truncated: bool,
-    pub timed_out: bool,
-    pub duration_ms: u64,
+pub(crate) struct DispatchResult {
+    pub(crate) subcommand: String,
+    pub(crate) exit_code: i32,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) truncated: bool,
+    pub(crate) timed_out: bool,
+    pub(crate) duration_ms: u64,
 }
 
 /// Parse a dispatch context string into (subcommand, args).
@@ -80,7 +80,7 @@ pub struct DispatchResult {
 /// - `Ok(Some((subcommand, args)))` if parsing succeeds and the subcommand is allowed.
 /// - `Err(message)` if the context contains shell metacharacters, a denied subcommand,
 ///   or an unknown subcommand.
-pub fn parse_dispatch_command(
+pub(crate) fn parse_dispatch_command(
     context: &str,
     extra_allowed: &[String],
 ) -> Result<Option<(String, Vec<String>)>, String> {
@@ -171,7 +171,7 @@ fn tokenize(input: &str) -> Result<Vec<String>, String> {
 /// Runs `config.agent_binary subcommand [args...] --robot` with stdout/stderr
 /// captured. Applies timeout and output byte cap. On timeout, kills the child
 /// process.
-pub async fn execute_dispatch(
+pub(crate) async fn execute_dispatch(
     config: &ShellDispatchConfig,
     subcommand: &str,
     args: &[String],
@@ -254,7 +254,7 @@ fn truncate_output(
 }
 
 /// Format a dispatch result as a markdown comment for posting to Gitea.
-pub fn format_dispatch_result(
+pub(crate) fn format_dispatch_result(
     result: &DispatchResult,
     agent_name: &str,
     session_id: &str,

--- a/crates/terraphim_agent/src/shell_dispatch.rs
+++ b/crates/terraphim_agent/src/shell_dispatch.rs
@@ -1,0 +1,609 @@
+//! Shell dispatch bridge for executing terraphim-agent subcommands.
+//!
+//! Parses context from `@adf:<agent-name>` mentions into subcommand + args,
+//! executes via `tokio::process::Command` (no shell invocation), and formats
+//! the result as a Gitea-compatible markdown comment.
+//!
+//! Security:
+//! - Subcommand allowlist with explicit deny list for dangerous commands
+//! - Shell metacharacter rejection (no shell expansion possible)
+//! - Output truncation at 48KB, 5-minute timeout with process kill
+//! - `--robot` always appended to args, no `--server` passthrough
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// Maximum bytes captured from stdout+stderr before truncation.
+pub const MAX_OUTPUT_BYTES: usize = 48_000;
+
+/// Default execution timeout in seconds.
+pub const DISPATCH_TIMEOUT_SECS: u64 = 300;
+
+/// Subcommands that are safe to execute from an @adf mention.
+pub const ALLOWED_SUBCOMMANDS: &[&str] = &[
+    "search",
+    "extract",
+    "replace",
+    "validate",
+    "suggest",
+    "graph",
+    "roles",
+    "config",
+    "learn",
+    "chat",
+    "check-update",
+    "guard",
+    "hook",
+    "evaluate",
+];
+
+/// Subcommands explicitly denied to prevent recursion, side effects, or
+/// interactive modes.
+pub const DENIED_SUBCOMMANDS: &[&str] = &[
+    "listen",
+    "repl",
+    "interactive",
+    "setup",
+    "update",
+    "sessions",
+];
+
+/// Shell metacharacters that must never appear in unquoted context.
+const SHELL_METACHARS: &[char] = &['|', ';', '&', '`', '$', '(', ')', '<', '>'];
+
+/// Configuration for the shell dispatch bridge.
+#[derive(Debug, Clone)]
+pub struct ShellDispatchConfig {
+    pub agent_binary: PathBuf,
+    pub max_output_bytes: usize,
+    pub timeout: Duration,
+    pub extra_allowed: Vec<String>,
+    pub working_dir: Option<PathBuf>,
+}
+
+/// Result of executing a dispatched subcommand.
+#[derive(Debug)]
+pub struct DispatchResult {
+    pub subcommand: String,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub truncated: bool,
+    pub timed_out: bool,
+    pub duration_ms: u64,
+}
+
+/// Parse a dispatch context string into (subcommand, args).
+///
+/// Returns:
+/// - `Ok(None)` if the context is empty or whitespace-only.
+/// - `Ok(Some((subcommand, args)))` if parsing succeeds and the subcommand is allowed.
+/// - `Err(message)` if the context contains shell metacharacters, a denied subcommand,
+///   or an unknown subcommand.
+pub fn parse_dispatch_command(
+    context: &str,
+    extra_allowed: &[String],
+) -> Result<Option<(String, Vec<String>)>, String> {
+    let trimmed = context.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    // Reject shell metacharacters anywhere in the raw context
+    for ch in SHELL_METACHARS {
+        if trimmed.contains(*ch) {
+            return Err(format!(
+                "shell metacharacter `{}` is not allowed in dispatch context",
+                ch
+            ));
+        }
+    }
+
+    let tokens = tokenize(trimmed)?;
+    if tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let subcommand = &tokens[0];
+    let args: Vec<String> = tokens[1..].to_vec();
+
+    // Check deny list first
+    if DENIED_SUBCOMMANDS.contains(&subcommand.as_str()) {
+        return Err(format!(
+            "subcommand `{}` is denied for dispatch execution",
+            subcommand
+        ));
+    }
+
+    // Check allow list (built-in + extra)
+    let allowed = ALLOWED_SUBCOMMANDS.contains(&subcommand.as_str())
+        || extra_allowed.iter().any(|s| s == subcommand);
+    if !allowed {
+        return Err(format!(
+            "subcommand `{}` is not in the dispatch allowlist",
+            subcommand
+        ));
+    }
+
+    Ok(Some((subcommand.clone(), args)))
+}
+
+/// Simple tokenizer that handles double-quoted strings.
+///
+/// No shell expansion, no backslash escapes, no single quotes.
+/// Tokens are split on whitespace. Double-quoted strings preserve
+/// interior whitespace as a single token.
+fn tokenize(input: &str) -> Result<Vec<String>, String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let chars = input.chars();
+
+    for ch in chars {
+        match ch {
+            '"' => {
+                in_quotes = !in_quotes;
+            }
+            ' ' | '\t' if !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => {
+                current.push(ch);
+            }
+        }
+    }
+
+    if in_quotes {
+        return Err("unterminated double quote in dispatch context".to_string());
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    Ok(tokens)
+}
+
+/// Execute a subcommand via `tokio::process::Command`.
+///
+/// Runs `config.agent_binary subcommand [args...] --robot` with stdout/stderr
+/// captured. Applies timeout and output byte cap. On timeout, kills the child
+/// process.
+pub async fn execute_dispatch(
+    config: &ShellDispatchConfig,
+    subcommand: &str,
+    args: &[String],
+) -> Result<DispatchResult, String> {
+    let start = Instant::now();
+
+    let mut cmd_args = vec![subcommand.to_string()];
+    cmd_args.extend(args.iter().cloned());
+    cmd_args.push("--robot".to_string());
+
+    let mut command = tokio::process::Command::new(&config.agent_binary);
+    command
+        .args(&cmd_args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    if let Some(ref dir) = config.working_dir {
+        command.current_dir(dir);
+    }
+
+    let child = command
+        .spawn()
+        .map_err(|e| format!("failed to spawn `{}`: {}", config.agent_binary.display(), e))?;
+
+    match tokio::time::timeout(config.timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let (stdout, stderr, truncated) =
+                truncate_output(&output.stdout, &output.stderr, config.max_output_bytes);
+
+            Ok(DispatchResult {
+                subcommand: subcommand.to_string(),
+                exit_code: output.status.code().unwrap_or(-1),
+                stdout,
+                stderr,
+                truncated,
+                timed_out: false,
+                duration_ms,
+            })
+        }
+        Ok(Err(e)) => Err(format!("child process error: {}", e)),
+        Err(_) => {
+            // Timeout expired
+            let duration_ms = start.elapsed().as_millis() as u64;
+            Ok(DispatchResult {
+                subcommand: subcommand.to_string(),
+                exit_code: -1,
+                stdout: String::new(),
+                stderr: format!("Process timed out after {}s", config.timeout.as_secs()),
+                truncated: false,
+                timed_out: true,
+                duration_ms,
+            })
+        }
+    }
+}
+
+/// Truncate combined stdout+stderr to fit within byte budget.
+fn truncate_output(
+    stdout_bytes: &[u8],
+    stderr_bytes: &[u8],
+    max_bytes: usize,
+) -> (String, String, bool) {
+    let total = stdout_bytes.len() + stderr_bytes.len();
+    if total <= max_bytes {
+        let stdout = String::from_utf8_lossy(stdout_bytes).to_string();
+        let stderr = String::from_utf8_lossy(stderr_bytes).to_string();
+        return (stdout, stderr, false);
+    }
+
+    // Prioritize stdout; give stderr whatever remains
+    let stdout_budget = max_bytes.min(stdout_bytes.len());
+    let stderr_budget = max_bytes.saturating_sub(stdout_budget);
+
+    let stdout = String::from_utf8_lossy(&stdout_bytes[..stdout_budget]).to_string();
+    let stderr =
+        String::from_utf8_lossy(&stderr_bytes[..stderr_budget.min(stderr_bytes.len())]).to_string();
+
+    (stdout, stderr, true)
+}
+
+/// Format a dispatch result as a markdown comment for posting to Gitea.
+pub fn format_dispatch_result(
+    result: &DispatchResult,
+    agent_name: &str,
+    session_id: &str,
+    event_id: &str,
+) -> String {
+    let duration_secs = result.duration_ms as f64 / 1000.0;
+    let mut out = String::new();
+
+    // Header
+    out.push_str(&format!(
+        "## `{}` -- exit {} ({:.1}s)\n\n",
+        result.subcommand, result.exit_code, duration_secs
+    ));
+
+    // Timeout marker
+    if result.timed_out {
+        out.push_str(&format!(
+            "**TIMED OUT** after {}s\n\n",
+            result.duration_ms / 1000
+        ));
+    }
+
+    // Truncation marker
+    if result.truncated {
+        out.push_str("[output truncated at 48KB]\n\n");
+    }
+
+    // Stdout
+    if !result.stdout.is_empty() {
+        out.push_str("```\n");
+        out.push_str(&result.stdout);
+        if !result.stdout.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("```\n\n");
+    }
+
+    // Stderr (collapsible)
+    if !result.stderr.is_empty() {
+        out.push_str(&format!(
+            "<details><summary>stderr ({} bytes)</summary>\n\n```\n",
+            result.stderr.len()
+        ));
+        out.push_str(&result.stderr);
+        if !result.stderr.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("```\n</details>\n\n");
+    }
+
+    // Footer
+    out.push_str(&format!(
+        "agent={} session={} event={}",
+        agent_name, session_id, event_id
+    ));
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_dispatch_command tests ──
+
+    #[test]
+    fn test_parse_empty_context() {
+        assert_eq!(parse_dispatch_command("", &[]).unwrap(), None);
+        assert_eq!(parse_dispatch_command("   ", &[]).unwrap(), None);
+        assert_eq!(parse_dispatch_command("\t\n", &[]).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_simple_command() {
+        let result = parse_dispatch_command("search automata", &[]).unwrap();
+        assert_eq!(
+            result,
+            Some(("search".to_string(), vec!["automata".to_string()]))
+        );
+    }
+
+    #[test]
+    fn test_parse_quoted_args() {
+        let result = parse_dispatch_command(r#"search "multi word""#, &[]).unwrap();
+        assert_eq!(
+            result,
+            Some(("search".to_string(), vec!["multi word".to_string()]))
+        );
+    }
+
+    #[test]
+    fn test_parse_learn_subcommand() {
+        let result = parse_dispatch_command("learn list", &[]).unwrap();
+        assert_eq!(
+            result,
+            Some(("learn".to_string(), vec!["list".to_string()]))
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_pipe() {
+        let err = parse_dispatch_command("search | cat", &[]).unwrap_err();
+        assert!(err.contains("metacharacter"), "error: {}", err);
+    }
+
+    #[test]
+    fn test_parse_rejects_semicolon() {
+        let err = parse_dispatch_command("search; rm", &[]).unwrap_err();
+        assert!(err.contains("metacharacter"), "error: {}", err);
+    }
+
+    #[test]
+    fn test_parse_rejects_backtick() {
+        let err = parse_dispatch_command("search `whoami`", &[]).unwrap_err();
+        assert!(err.contains("metacharacter"), "error: {}", err);
+    }
+
+    #[test]
+    fn test_parse_rejects_dollar() {
+        let err = parse_dispatch_command("search $HOME", &[]).unwrap_err();
+        assert!(err.contains("metacharacter"), "error: {}", err);
+    }
+
+    #[test]
+    fn test_parse_rejects_denied() {
+        let err = parse_dispatch_command("listen --identity x", &[]).unwrap_err();
+        assert!(err.contains("denied"), "error: {}", err);
+    }
+
+    #[test]
+    fn test_parse_rejects_unknown() {
+        let err = parse_dispatch_command("foobar", &[]).unwrap_err();
+        assert!(err.contains("allowlist"), "error: {}", err);
+    }
+
+    #[test]
+    fn test_parse_allows_extra() {
+        let extra = vec!["custom".to_string()];
+        let result = parse_dispatch_command("custom arg", &extra).unwrap();
+        assert_eq!(
+            result,
+            Some(("custom".to_string(), vec!["arg".to_string()]))
+        );
+    }
+
+    #[test]
+    fn test_parse_subcommand_only_no_args() {
+        let result = parse_dispatch_command("roles", &[]).unwrap();
+        assert_eq!(result, Some(("roles".to_string(), vec![])));
+    }
+
+    #[test]
+    fn test_parse_multiple_args() {
+        let result = parse_dispatch_command("search automata --role engineer", &[]).unwrap();
+        assert_eq!(
+            result,
+            Some((
+                "search".to_string(),
+                vec![
+                    "automata".to_string(),
+                    "--role".to_string(),
+                    "engineer".to_string()
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_angle_brackets() {
+        assert!(parse_dispatch_command("search > /tmp/out", &[]).is_err());
+        assert!(parse_dispatch_command("search < /etc/passwd", &[]).is_err());
+    }
+
+    #[test]
+    fn test_parse_rejects_ampersand() {
+        assert!(parse_dispatch_command("search & echo", &[]).is_err());
+    }
+
+    #[test]
+    fn test_parse_rejects_parentheses() {
+        assert!(parse_dispatch_command("search (test)", &[]).is_err());
+    }
+
+    // ── format_dispatch_result tests ──
+
+    #[test]
+    fn test_format_success() {
+        let result = DispatchResult {
+            subcommand: "search".to_string(),
+            exit_code: 0,
+            stdout: "found 3 results\n".to_string(),
+            stderr: String::new(),
+            truncated: false,
+            timed_out: false,
+            duration_ms: 150,
+        };
+        let formatted = format_dispatch_result(&result, "worker", "ses:abc", "evt:def");
+        assert!(formatted.contains("## `search` -- exit 0"));
+        assert!(formatted.contains("found 3 results"));
+        assert!(formatted.contains("session=ses:abc"));
+        assert!(formatted.contains("event=evt:def"));
+        assert!(!formatted.contains("stderr"));
+        assert!(!formatted.contains("truncated"));
+        assert!(!formatted.contains("TIMED OUT"));
+    }
+
+    #[test]
+    fn test_format_failure() {
+        let result = DispatchResult {
+            subcommand: "search".to_string(),
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "error: no config found\n".to_string(),
+            truncated: false,
+            timed_out: false,
+            duration_ms: 50,
+        };
+        let formatted = format_dispatch_result(&result, "worker", "ses:abc", "evt:def");
+        assert!(formatted.contains("exit 1"));
+        assert!(formatted.contains("stderr"));
+        assert!(formatted.contains("error: no config found"));
+    }
+
+    #[test]
+    fn test_format_truncated() {
+        let result = DispatchResult {
+            subcommand: "search".to_string(),
+            exit_code: 0,
+            stdout: "partial output\n".to_string(),
+            stderr: String::new(),
+            truncated: true,
+            timed_out: false,
+            duration_ms: 200,
+        };
+        let formatted = format_dispatch_result(&result, "worker", "ses:abc", "evt:def");
+        assert!(formatted.contains("[output truncated at 48KB]"));
+    }
+
+    #[test]
+    fn test_format_timeout() {
+        let result = DispatchResult {
+            subcommand: "chat".to_string(),
+            exit_code: -1,
+            stdout: String::new(),
+            stderr: "Process timed out after 300s".to_string(),
+            truncated: false,
+            timed_out: true,
+            duration_ms: 300_000,
+        };
+        let formatted = format_dispatch_result(&result, "worker", "ses:abc", "evt:def");
+        assert!(formatted.contains("**TIMED OUT**"));
+        assert!(formatted.contains("300s"));
+    }
+
+    // ── tokenize tests ──
+
+    #[test]
+    fn test_tokenize_simple() {
+        let tokens = tokenize("search automata").unwrap();
+        assert_eq!(tokens, vec!["search", "automata"]);
+    }
+
+    #[test]
+    fn test_tokenize_quoted() {
+        let tokens = tokenize(r#"search "hello world" extra"#).unwrap();
+        assert_eq!(tokens, vec!["search", "hello world", "extra"]);
+    }
+
+    #[test]
+    fn test_tokenize_unterminated_quote() {
+        assert!(tokenize(r#"search "unterminated"#).is_err());
+    }
+
+    #[test]
+    fn test_tokenize_empty() {
+        let tokens = tokenize("").unwrap();
+        assert!(tokens.is_empty());
+    }
+
+    // ── execute_dispatch tests ──
+
+    #[tokio::test]
+    async fn test_execute_dispatch_captures_stdout() {
+        let config = ShellDispatchConfig {
+            agent_binary: PathBuf::from("/bin/echo"),
+            max_output_bytes: MAX_OUTPUT_BYTES,
+            timeout: Duration::from_secs(5),
+            extra_allowed: vec![],
+            working_dir: None,
+        };
+        // /bin/echo "hello" "--robot" => "hello --robot\n"
+        let result = execute_dispatch(&config, "hello", &[]).await.unwrap();
+        // echo receives args: "hello", "--robot"
+        assert!(
+            result.stdout.contains("hello"),
+            "stdout was: {}",
+            result.stdout
+        );
+        assert_eq!(result.exit_code, 0);
+        assert!(!result.timed_out);
+        assert!(!result.truncated);
+    }
+
+    #[tokio::test]
+    async fn test_execute_dispatch_captures_exit_code() {
+        let config = ShellDispatchConfig {
+            agent_binary: PathBuf::from("/bin/false"),
+            max_output_bytes: MAX_OUTPUT_BYTES,
+            timeout: Duration::from_secs(5),
+            extra_allowed: vec![],
+            working_dir: None,
+        };
+        // /bin/false ignores all args and exits 1
+        let result = execute_dispatch(&config, "anything", &[]).await.unwrap();
+        assert_ne!(result.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn test_execute_dispatch_nonexistent_binary() {
+        let config = ShellDispatchConfig {
+            agent_binary: PathBuf::from("/nonexistent/binary"),
+            max_output_bytes: MAX_OUTPUT_BYTES,
+            timeout: Duration::from_secs(5),
+            extra_allowed: vec![],
+            working_dir: None,
+        };
+        let err = execute_dispatch(&config, "search", &[]).await.unwrap_err();
+        assert!(err.contains("failed to spawn"), "error: {}", err);
+    }
+
+    // ── truncate_output tests ──
+
+    #[test]
+    fn test_truncate_output_within_budget() {
+        let stdout = b"hello";
+        let stderr = b"world";
+        let (s, e, truncated) = truncate_output(stdout, stderr, 100);
+        assert_eq!(s, "hello");
+        assert_eq!(e, "world");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_truncate_output_over_budget() {
+        let stdout = vec![b'A'; 100];
+        let stderr = vec![b'B'; 100];
+        let (s, e, truncated) = truncate_output(&stdout, &stderr, 150);
+        assert_eq!(s.len(), 100);
+        assert_eq!(e.len(), 50);
+        assert!(truncated);
+    }
+}

--- a/crates/terraphim_agent/src/shell_dispatch.rs
+++ b/crates/terraphim_agent/src/shell_dispatch.rs
@@ -52,13 +52,27 @@ pub(crate) const DENIED_SUBCOMMANDS: &[&str] = &[
 const SHELL_METACHARS: &[char] = &['|', ';', '&', '`', '$', '(', ')', '<', '>'];
 
 /// Configuration for the shell dispatch bridge.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct ShellDispatchConfig {
     pub(crate) agent_binary: PathBuf,
     pub(crate) max_output_bytes: usize,
     pub(crate) timeout: Duration,
     pub(crate) extra_allowed: Vec<String>,
     pub(crate) working_dir: Option<PathBuf>,
+    pub(crate) guard: std::sync::Arc<crate::guard_patterns::CommandGuard>,
+}
+
+impl std::fmt::Debug for ShellDispatchConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShellDispatchConfig")
+            .field("agent_binary", &self.agent_binary)
+            .field("max_output_bytes", &self.max_output_bytes)
+            .field("timeout", &self.timeout)
+            .field("extra_allowed", &self.extra_allowed)
+            .field("working_dir", &self.working_dir)
+            .field("guard", &"<CommandGuard>")
+            .finish()
+    }
 }
 
 /// Result of executing a dispatched subcommand.
@@ -181,8 +195,7 @@ pub(crate) async fn execute_dispatch(
         .chain(args.iter().cloned())
         .collect::<Vec<_>>()
         .join(" ");
-    let guard = crate::guard_patterns::CommandGuard::new();
-    let guard_result = guard.check(&full_command);
+    let guard_result = config.guard.check(&full_command);
     if guard_result.decision != crate::guard_patterns::GuardDecision::Allow {
         return Err(format!(
             "Guard blocked command `{}`: {} (pattern: {})",
@@ -552,15 +565,20 @@ mod tests {
 
     // ── execute_dispatch tests ──
 
-    #[tokio::test]
-    async fn test_execute_dispatch_captures_stdout() {
-        let config = ShellDispatchConfig {
-            agent_binary: PathBuf::from("/bin/echo"),
+    fn test_config(binary: &str) -> ShellDispatchConfig {
+        ShellDispatchConfig {
+            agent_binary: PathBuf::from(binary),
             max_output_bytes: MAX_OUTPUT_BYTES,
             timeout: Duration::from_secs(5),
             extra_allowed: vec![],
             working_dir: None,
-        };
+            guard: std::sync::Arc::new(crate::guard_patterns::CommandGuard::new()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_dispatch_captures_stdout() {
+        let config = test_config("/bin/echo");
         // /bin/echo "hello" "--robot" => "hello --robot\n"
         let result = execute_dispatch(&config, "hello", &[]).await.unwrap();
         // echo receives args: "hello", "--robot"
@@ -576,13 +594,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_dispatch_captures_exit_code() {
-        let config = ShellDispatchConfig {
-            agent_binary: PathBuf::from("/bin/false"),
-            max_output_bytes: MAX_OUTPUT_BYTES,
-            timeout: Duration::from_secs(5),
-            extra_allowed: vec![],
-            working_dir: None,
-        };
+        let config = test_config("/bin/false");
         // /bin/false ignores all args and exits 1
         let result = execute_dispatch(&config, "anything", &[]).await.unwrap();
         assert_ne!(result.exit_code, 0);
@@ -590,13 +602,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_dispatch_nonexistent_binary() {
-        let config = ShellDispatchConfig {
-            agent_binary: PathBuf::from("/nonexistent/binary"),
-            max_output_bytes: MAX_OUTPUT_BYTES,
-            timeout: Duration::from_secs(5),
-            extra_allowed: vec![],
-            working_dir: None,
-        };
+        let config = test_config("/nonexistent/binary");
         let err = execute_dispatch(&config, "search", &[]).await.unwrap_err();
         assert!(err.contains("failed to spawn"), "error: {}", err);
     }
@@ -627,13 +633,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_dispatch_blocks_destructive_command() {
-        let config = ShellDispatchConfig {
-            agent_binary: PathBuf::from("/bin/echo"),
-            max_output_bytes: MAX_OUTPUT_BYTES,
-            timeout: Duration::from_secs(5),
-            extra_allowed: vec![],
-            working_dir: None,
-        };
+        let config = test_config("/bin/echo");
         // "git reset --hard" should be caught by the guard
         let result = execute_dispatch(&config, "guard", &["git reset --hard".to_string()]).await;
         // The guard should block this -- the args contain a destructive pattern
@@ -648,13 +648,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_dispatch_allows_safe_command() {
-        let config = ShellDispatchConfig {
-            agent_binary: PathBuf::from("/bin/echo"),
-            max_output_bytes: MAX_OUTPUT_BYTES,
-            timeout: Duration::from_secs(5),
-            extra_allowed: vec![],
-            working_dir: None,
-        };
+        let config = test_config("/bin/echo");
         // "search automata" is safe -- guard should allow
         let result = execute_dispatch(&config, "search", &["automata".to_string()]).await;
         assert!(

--- a/crates/terraphim_agent/src/shell_dispatch.rs
+++ b/crates/terraphim_agent/src/shell_dispatch.rs
@@ -176,6 +176,22 @@ pub(crate) async fn execute_dispatch(
     subcommand: &str,
     args: &[String],
 ) -> Result<DispatchResult, String> {
+    // Run guard check on the full command before executing
+    let full_command = std::iter::once(subcommand.to_string())
+        .chain(args.iter().cloned())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let guard = crate::guard_patterns::CommandGuard::new();
+    let guard_result = guard.check(&full_command);
+    if guard_result.decision != crate::guard_patterns::GuardDecision::Allow {
+        return Err(format!(
+            "Guard blocked command `{}`: {} (pattern: {})",
+            full_command,
+            guard_result.reason.unwrap_or_default(),
+            guard_result.pattern.unwrap_or_default(),
+        ));
+    }
+
     let start = Instant::now();
 
     let mut cmd_args = vec![subcommand.to_string()];
@@ -605,5 +621,46 @@ mod tests {
         assert_eq!(s.len(), 100);
         assert_eq!(e.len(), 50);
         assert!(truncated);
+    }
+
+    // ── guard integration tests ──
+
+    #[tokio::test]
+    async fn test_execute_dispatch_blocks_destructive_command() {
+        let config = ShellDispatchConfig {
+            agent_binary: PathBuf::from("/bin/echo"),
+            max_output_bytes: MAX_OUTPUT_BYTES,
+            timeout: Duration::from_secs(5),
+            extra_allowed: vec![],
+            working_dir: None,
+        };
+        // "git reset --hard" should be caught by the guard
+        let result = execute_dispatch(&config, "guard", &["git reset --hard".to_string()]).await;
+        // The guard should block this -- the args contain a destructive pattern
+        // Note: the guard checks the joined command string "guard git reset --hard"
+        // which contains "git reset --hard", a known destructive pattern
+        assert!(
+            result.is_err() || result.as_ref().is_ok_and(|r| r.exit_code != 0),
+            "Guard should block or fail on destructive command pattern, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_dispatch_allows_safe_command() {
+        let config = ShellDispatchConfig {
+            agent_binary: PathBuf::from("/bin/echo"),
+            max_output_bytes: MAX_OUTPUT_BYTES,
+            timeout: Duration::from_secs(5),
+            extra_allowed: vec![],
+            working_dir: None,
+        };
+        // "search automata" is safe -- guard should allow
+        let result = execute_dispatch(&config, "search", &["automata".to_string()]).await;
+        assert!(
+            result.is_ok(),
+            "Guard should allow safe command: {:?}",
+            result
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Listener now executes terraphim-agent subcommands when triggered by `@adf:` mentions
- Parses context text after `@adf:name` as CLI subcommand + args
- Executes via `tokio::process::Command` (no shell, direct execvp)
- Posts results as markdown Gitea comments
- Specialist routing via `specialist_routes` config map
- Full backward compatibility (omitting `dispatch` config = claim-only)

## Security

- Subcommand allowlist (search, replace, learn, evaluate, etc.)
- Deny list prevents recursion (listen, repl, setup, update)
- Shell metacharacter rejection (|, ;, &, `, $)
- 48KB output truncation, 5-minute timeout
- No new crate dependencies

## Example

```
Comment: @adf:terraphim-worker search "automata"
  -> Claims issue, posts ACK
  -> Runs: terraphim-agent search "automata" --robot
  -> Posts JSON results as markdown comment
```

## Test plan

- [x] 29 new tests (parsing, execution, formatting, edge cases)
- [x] All 313 existing tests pass (zero regressions)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] CI green

Refs #577