### PR TITLE
fix(orchestrator): respect KG action template CLI tool in routing engine

### DIFF
--- a/crates/terraphim_orchestrator/src/lib.rs
+++ b/crates/terraphim_orchestrator/src/lib.rs
@@ -1000,6 +1000,11 @@ impl AgentOrchestrator {
             if decision.candidate.model.is_empty() {
                 None
             } else {
+                // Extract CLI tool override from routing decision so that
+                // anthropic models routed via KG use claude CLI, not opencode.
+                if decision.candidate.cli_tool != def.cli_tool {
+                    kg_cli_override = Some(decision.candidate.cli_tool.clone());
+                }
                 Some(decision.candidate.model)
             }
         } else if supports_model_flag {

--- a/docs/taxonomy/routing_scenarios/adf/implementation_tier.md
+++ b/docs/taxonomy/routing_scenarios/adf/implementation_tier.md
@@ -21,7 +21,7 @@ synonyms:: disciplined-implementation
 
 trigger:: code writing, review, testing, and mid-complexity development tasks
 
-route:: anthropic, claude-sonnet-4-6
+route:: anthropic, sonnet
 action:: /home/alex/.local/bin/claude --model {{ model }} -p "{{ prompt }}" --max-turns 50
 
 route:: kimi, kimi-for-coding/k2p5

--- a/docs/taxonomy/routing_scenarios/adf/planning_tier.md
+++ b/docs/taxonomy/routing_scenarios/adf/planning_tier.md
@@ -16,7 +16,7 @@ synonyms:: disciplined-research, disciplined-design
 
 trigger:: tasks requiring deep reasoning, architecture decisions, or strategic planning
 
-route:: anthropic, claude-opus-4-6
+route:: anthropic, opus
 action:: /home/alex/.local/bin/claude --model {{ model }} -p "{{ prompt }}" --max-turns 50
 
 route:: openai, openai/gpt-5.4

--- a/docs/taxonomy/routing_scenarios/adf/review_tier.md
+++ b/docs/taxonomy/routing_scenarios/adf/review_tier.md
@@ -17,7 +17,7 @@ synonyms:: disciplined-verification, disciplined-validation
 
 trigger:: verification, validation, and review tasks that check existing work
 
-route:: anthropic, claude-haiku-4-5
+route:: anthropic, haiku
 action:: /home/alex/.local/bin/claude --model {{ model }} -p "{{ prompt }}" --max-turns 30
 
 route:: openai, openai/gpt-5.4-mini


### PR DESCRIPTION
## Summary

- Fix routing engine to extract `cli_tool` from `RoutingDecision.candidate` when `use_routing_engine = true`, so that KG action templates (e.g. `/home/alex/.local/bin/claude`) override the agent default `cli_tool` (e.g. `opencode`)
- Update taxonomy model names from version-pinned to Claude CLI aliases (`haiku`, `sonnet`, `opus`) so they resolve to latest automatically

## Problem

When `use_routing_engine = true`, the `RoutingDecisionEngine` returns both `model` and `cli_tool` from the KG route action template, but `spawn_agent()` only extracted the model and discarded the CLI tool. Agents with `cli_tool = opencode` stayed on opencode even when KG routes specified claude CLI for anthropic models.

## Testing

- 412 orchestrator tests pass
- Deployed on bigbox, verified end-to-end: `@adf:developer` mention detected, KG routed to `haiku` via `review_tier`, agent spawned with `cli=/home/alex/.local/bin/claude model=Some("haiku")`, completed successfully

Refs #579