### PR TITLE
Migrate shared learning store to markdown backend

### DIFF
--- a/.docs/design-shared-learning-store-migration-2026-04-19.md
+++ b/.docs/design-shared-learning-store-migration-2026-04-19.md
@@ -1,0 +1,333 @@
+# Implementation Plan: Shared Learning Store Markdown Backend Migration
+
+**Status**: Approved
+**Research Doc**: `.docs/research-shared-learning-store-migration-2026-04-19.md`
+**Author**: Terraphim AI Agent
+**Date**: 2026-04-19
+**Estimated Effort**: 0.5-1 day
+
+## Overview
+
+### Summary
+
+This plan makes `SharedLearningStore` durable by replacing its current in-memory-only persistence path with `MarkdownLearningStore`, while preserving the existing store API, BM25 deduplication, and trust-promotion behaviour.
+
+### Approach
+
+Keep `SharedLearningStore` as the high-level API and in-memory index. Remove the unused `DeviceStorage` dependency from `store.rs`, extend `MarkdownLearningStore` so it can round-trip the full `SharedLearning` payload, and load all persisted markdown learnings during `open()`, collapsing canonical and shared copies into one in-memory record per `learning.id`.
+
+### Scope
+
+**In Scope:**
+- Expand markdown frontmatter coverage to preserve full `SharedLearning` fidelity
+- Add de-duplicated markdown loading for `SharedLearningStore::open()`
+- Replace fake persistence in `store.rs` with markdown-backed persistence
+- Align default learning paths with `ProjectDirs` guidance
+- Update unit and integration tests to verify restart durability
+
+**Out of Scope:**
+- Rewriting ranking or deduplication logic
+- Changing CLI command shapes
+- Auto-publishing promoted learnings to `shared/`
+- Refactoring injector behaviour
+- Introducing a new database or queue
+
+**Avoid At All Cost** (from 5/25 analysis):
+- Keeping partial markdown serialisation that drops metadata
+- Loading canonical and shared copies without deterministic de-duplication
+- Introducing another storage abstraction layer without a concrete need
+- Broad refactors to CLI, injector, or wiki sync in the same change
+
+## Architecture
+
+### Component Diagram
+
+```text
+SharedLearningStore
+  |- config: StoreConfig
+  |- backend: MarkdownLearningStore
+  `- index: RwLock<HashMap<String, SharedLearning>>
+
+open()
+  -> backend.list_all()
+  -> de-duplicate by learning.id
+  -> populate index
+
+insert()/merge()/promote()/record_application()
+  -> mutate index
+  -> backend.save(&learning)
+
+Injector / shared publication
+  -> continue using shared markdown files separately
+```
+
+### Data Flow
+
+```text
+Process start
+  -> SharedLearningStore::open(config)
+  -> MarkdownLearningStore::list_all()
+  -> de-duplicate by learning.id, preferring non-shared path
+  -> index populated from markdown files
+
+Mutation
+  -> SharedLearningStore mutates learning in memory
+  -> MarkdownLearningStore::save(&learning)
+
+Process restart
+  -> open() reloads same markdown file
+  -> learning state is preserved
+```
+
+### Key Design Decisions
+
+| Decision | Rationale | Alternatives Rejected |
+|----------|-----------|----------------------|
+| Keep `SharedLearningStore` as the public store type | Preserves CLI and test callers, and keeps BM25 logic in one place | Replacing callers with `MarkdownLearningStore` directly |
+| Use direct markdown backend rather than `terraphim_persistence` for this step | Existing markdown backend already works; current `DeviceStorage` path is effectively dead code | Adding another abstraction layer before solving durability |
+| Make markdown frontmatter fully represent `SharedLearning` | Prevents silent state loss on restart | Persisting only a subset of fields |
+| Load both canonical and shared markdown files, then de-duplicate by `learning.id` | Matches approved direction while keeping one logical record in the store index | Excluding `shared/` entirely |
+
+### Eliminated Options (Essentialism)
+
+| Option Rejected | Why Rejected | Risk of Including |
+|-----------------|--------------|-------------------|
+| Backend trait for one implementation | No immediate need; adds ceremony | More code paths to maintain |
+| Auto-save promoted L2/L3 learnings to `shared/` during this step | Changes behaviour and confuses canonical persistence with distribution | Duplicate records, harder rollback |
+| Full rewrite around orchestrator persistence patterns | Useful reference, but too broad here | Delays the actual durability fix |
+
+### Simplicity Check
+
+**What if this could be easy?**
+
+It can. The easiest correct solution is:
+
+1. One canonical markdown file per learning.
+2. One de-duplicated store index loaded at startup.
+3. One save path for mutations.
+4. Shared publication handled separately.
+
+No database, no new trait stack, no behavioural rewrite.
+
+**Senior Engineer Test**: This is a small persistence swap with explicit fidelity guarantees, not a storage-platform project.
+
+**Nothing Speculative Checklist**:
+- [x] No features the user did not request
+- [x] No abstractions for hypothetical future backends
+- [x] No extra sync mechanism
+- [x] No new ranking logic
+- [x] No premature optimisation
+
+## File Changes
+
+### New Files
+
+None required.
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `crates/terraphim_agent/src/shared_learning/markdown_store.rs` | Expand frontmatter schema, expose path metadata needed for deterministic load-time de-duplication, align default path logic |
+| `crates/terraphim_agent/src/shared_learning/store.rs` | Remove `DeviceStorage`/`SharedLearningRecord`, add markdown backend field, implement real `load_all()` and markdown-backed `persist()` |
+| `crates/terraphim_agent/src/shared_learning/mod.rs` | Re-export any new config helpers if needed |
+| `crates/terraphim_agent/Cargo.toml` | Add `directories` dependency only if no existing helper can be reused cleanly |
+| `crates/terraphim_agent/tests/shared_learning_cli_tests.rs` | Move tests to temp-directory-backed durable store instances and add restart assertions |
+
+### Deleted Files
+
+None, but `store.rs` should delete dead `DeviceStorage`/`Persistable` glue inside the file if it becomes unused.
+
+## API Design
+
+### Public Types
+
+```rust
+#[derive(Debug, Clone)]
+pub struct StoreConfig {
+    pub similarity_threshold: f64,
+    pub auto_promote_l2: bool,
+    pub markdown: MarkdownStoreConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct MarkdownStoreConfig {
+    pub learnings_dir: PathBuf,
+    pub shared_dir_name: String,
+}
+```
+
+### Public Functions
+
+```rust
+impl SharedLearningStore {
+    pub async fn open(config: StoreConfig) -> Result<Self, StoreError>;
+}
+
+impl MarkdownLearningStore {
+    pub fn with_config(config: MarkdownStoreConfig) -> Self;
+
+    /// List persisted learnings across canonical and shared locations.
+    pub async fn list_all(&self) -> Result<Vec<SharedLearning>, MarkdownStoreError>;
+}
+```
+
+### Error Types
+
+```rust
+#[derive(Error, Debug)]
+pub enum StoreError {
+    #[error("persistence error: {0}")]
+    Persistence(String),
+    #[error("learning not found: {0}")]
+    NotFound(String),
+    #[error("BM25 calculation error: {0}")]
+    Bm25(String),
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+```
+
+No new public store error type is required if markdown backend errors are mapped into `StoreError::Persistence`.
+
+## Test Strategy
+
+### Unit Tests
+
+| Test | Location | Purpose |
+|------|----------|---------|
+| `test_save_and_load_roundtrip_preserves_full_state` | `markdown_store.rs` | Ensure all `SharedLearning` metadata survives markdown round-trip |
+| `test_list_all_supports_dedup_inputs` | `markdown_store.rs` | Ensure the backend can feed canonical and shared copies into deterministic store de-duplication |
+| `test_open_loads_existing_markdown_learnings` | `store.rs` | Verify startup hydration from persisted files |
+| `test_open_dedups_shared_and_canonical_copies` | `store.rs` | Ensure one logical record per `learning.id` after startup load |
+| `test_persist_after_promotion_and_application` | `store.rs` | Ensure quality metrics and trust promotion survive reload |
+| `test_sparse_old_frontmatter_still_loads` | `markdown_store.rs` | Backwards-compatible parsing for already-written markdown files |
+
+### Integration Tests
+
+| Test | Location | Purpose |
+|------|----------|---------|
+| `shared_list_with_trust_level_filter` | `shared_learning_cli_tests.rs` | Keep existing CLI behaviour intact with durable backend |
+| `shared_promote_l1_to_l2` | `shared_learning_cli_tests.rs` | Ensure promotion still works end-to-end |
+| `shared_store_survives_restart` | `shared_learning_cli_tests.rs` | Create store, insert data, reopen store, verify persistence |
+
+### Property / Invariant Tests
+
+No property tests are required for this step. The critical invariants are deterministic and best covered by round-trip tests.
+
+## Implementation Steps
+
+### Step 1: Expand Markdown Fidelity
+**Files:** `crates/terraphim_agent/src/shared_learning/markdown_store.rs`
+**Description:** Extend `LearningFrontmatter` and parsing logic so all persisted `SharedLearning` fields round-trip cleanly. Newly added fields should be optional/defaulted on read so older sparse files still load.
+**Tests:** Add full-state round-trip test and sparse-frontmatter compatibility test.
+**Estimated:** 2-3 hours
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct LearningFrontmatter {
+    id: String,
+    title: String,
+    agent_id: String,
+    captured_at: String,
+    updated_at: String,
+    promoted_at: Option<String>,
+    trust_level: String,
+    source: String,
+    applicable_agents: Vec<String>,
+    keywords: Vec<String>,
+    verify_pattern: Option<String>,
+    quality: QualityMetrics,
+    original_command: Option<String>,
+    error_context: Option<String>,
+    correction: Option<String>,
+    wiki_page_name: Option<String>,
+}
+```
+
+### Step 2: Add Canonical Listing and Path Helper
+**Files:** `crates/terraphim_agent/src/shared_learning/markdown_store.rs`, optionally `crates/terraphim_agent/Cargo.toml`
+**Description:** Ensure backend loading exposes both canonical and shared markdown files, with enough path context for deterministic de-duplication in `SharedLearningStore::load_all()`. Update default path construction to follow `ProjectDirs::from("com", "aks", "terraphim").data_local_dir()` while preserving `TERRAPHIM_LEARNINGS_DIR` override.
+**Tests:** Shared and canonical inputs are both discoverable; temp-dir config still works.
+**Dependencies:** Step 1
+**Estimated:** 1-2 hours
+
+### Step 3: Refactor `SharedLearningStore` to Use Markdown Backend
+**Files:** `crates/terraphim_agent/src/shared_learning/store.rs`
+**Description:** Replace the `DeviceStorage` field with `MarkdownLearningStore`, remove dead `SharedLearningRecord` persistence glue, implement real `load_all()`, de-duplicate by `learning.id` while preferring non-shared paths, and persist mutations through markdown saves.
+**Tests:** Existing store tests plus new startup hydration tests.
+**Dependencies:** Steps 1-2
+**Estimated:** 2-3 hours
+
+```rust
+pub struct SharedLearningStore {
+    backend: MarkdownLearningStore,
+    index: RwLock<HashMap<String, SharedLearning>>,
+    config: StoreConfig,
+}
+```
+
+### Step 4: Update Integration Tests for Durability
+**Files:** `crates/terraphim_agent/tests/shared_learning_cli_tests.rs`
+**Description:** Stop describing the store as in-memory. Use temp-directory-backed store configuration, reopen the store, and verify persisted state survives restart.
+**Tests:** Integration suite with `shared-learning` feature.
+**Dependencies:** Step 3
+**Estimated:** 1-2 hours
+
+## Rollback Plan
+
+If migration introduces unexpected regressions:
+
+1. Revert `store.rs` to the current in-memory-only implementation.
+2. Keep the expanded markdown serialiser if it is independently correct and tested.
+3. Preserve the new tests so the durability gap remains visible.
+
+## Migration
+
+### Data Migration
+
+No migration from the old `DeviceStorage` path is required because the current implementation does not perform durable loads.
+
+The only compatibility requirement is reading markdown files already created by the current `MarkdownLearningStore`, which use a sparse frontmatter schema.
+
+## Dependencies
+
+### New Dependencies
+
+| Crate | Version | Justification |
+|-------|---------|---------------|
+| `directories` | Current compatible version | Only if `terraphim_agent` cannot reuse an existing helper for `ProjectDirs` cleanly |
+
+### Dependency Updates
+
+None expected.
+
+## Performance Considerations
+
+### Expected Performance
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Store open | Acceptable for local CLI use with small-to-moderate learning set | Unit/integration tests |
+| Mutation cost | One file write per logical update | Code inspection + tests |
+| Query speed after open | Same as current in-memory behaviour | Existing store tests |
+
+### Benchmarks to Add
+
+No dedicated benchmark is required for this step.
+
+## Open Items
+
+| Item | Status | Owner |
+|------|--------|-------|
+| Decide whether to add `directories` directly or expose a shared helper | Pending | Human + implementer |
+| Approved: load `shared/` too and de-duplicate by `learning.id`, preferring non-shared copies | Resolved | Human approval |
+
+## Approval
+
+- [x] Technical review complete
+- [x] Test strategy defined
+- [x] Simplicity check passed
+- [x] Human approval received

--- a/.docs/research-shared-learning-store-migration-2026-04-19.md
+++ b/.docs/research-shared-learning-store-migration-2026-04-19.md
@@ -1,0 +1,258 @@
+# Research Document: Shared Learning Store Markdown Migration
+
+**Status**: Approved
+**Author**: Terraphim AI Agent
+**Date**: 2026-04-19
+**Reviewers**: Human approval required
+
+## Executive Summary
+
+`SharedLearningStore` currently presents a durable-storage API but is backed by `DeviceStorage::arc_memory_only()` and a no-op `load_all()`, so shared learnings disappear between process runs. A markdown backend already exists, but it is not yet a safe drop-in replacement because it serialises only part of `SharedLearning`, uses a different path strategy than the approved cross-platform recommendation, and can mix canonical learnings with shared copies.
+
+The approved Step 6 direction is a minimal migration: preserve the existing `SharedLearningStore` API, keep its in-memory index and BM25 logic, and replace only the fake persistence layer with `MarkdownLearningStore` after extending markdown round-tripping to cover the full `SharedLearning` state. Startup loading should read both canonical and shared markdown files, then de-duplicate by `learning.id`.
+
+## Essential Questions Check
+
+| Question | Answer | Evidence |
+|----------|--------|----------|
+| Energising? | Yes | This is the missing durability step in the approved Learning and KG plan, and it unblocks making the existing CLI commands genuinely useful across runs. |
+| Leverages strengths? | Yes | The codebase already has a markdown-first learning model, wiki sync, and a dedicated markdown store implementation. |
+| Meets real need? | Yes | `learn shared` commands currently imply persistent state, but `SharedLearningStore::open()` loads an in-memory backend and `load_all()` does nothing. |
+
+**Proceed**: Yes
+
+## Problem Statement
+
+### Description
+
+Step 6 needs to make `SharedLearningStore` durable without rewriting its higher-level behaviour. The current store API is used by the CLI and tests, but persistence is effectively stubbed.
+
+### Impact
+
+- Users can import, list, promote, and query shared learnings during one run, but those learnings are lost on restart.
+- Cross-agent work now has two persistence concepts: `SharedLearningStore` and `MarkdownLearningStore`, with no single canonical path.
+- The new injector and future sharing features risk diverging from the store used by the CLI.
+
+### Success Criteria
+
+- `SharedLearningStore` data survives process restart on the same machine.
+- Existing `SharedLearningStore` callers do not need signature changes.
+- Full `SharedLearning` fidelity is preserved when saving and reloading.
+- Canonical learnings and shared-directory copies do not appear as duplicate records in the store index.
+- Storage paths follow the approved `ProjectDirs::from("com", "aks", "terraphim")` direction, while still permitting explicit overrides for tests and power users.
+
+## Current State Analysis
+
+### Existing Implementation
+
+`crates/terraphim_agent/src/shared_learning/store.rs` contains the main store API used by the CLI. It holds an in-memory `RwLock<HashMap<String, SharedLearning>>`, implements deduplication and promotion logic, and calls `persist()` after mutations. However:
+
+- `open()` initialises `DeviceStorage::arc_memory_only()`.
+- `load_all()` only logs and returns `Ok(())`.
+- The `storage` field is not used for reads.
+- Durability is therefore implied by the API but not delivered by the implementation.
+
+`crates/terraphim_agent/src/shared_learning/markdown_store.rs` already provides filesystem-backed markdown save/load/list logic. It is close to the right backend, but it currently loses part of the domain model on round-trip:
+
+- `quality`
+- `applicable_agents`
+- `keywords`
+- `verify_pattern`
+- `updated_at`
+- `promoted_at`
+
+It also defaults to `dirs::data_local_dir()/terraphim/learnings`, while the approved cross-platform recommendation in `.docs/research-cross-platform-data-dirs.md` is `ProjectDirs::from("com", "aks", "terraphim").data_local_dir()`.
+
+### Code Locations
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| Shared learning API | `crates/terraphim_agent/src/shared_learning/store.rs` | Public store, BM25 deduplication, trust promotion, CLI backing |
+| Markdown backend | `crates/terraphim_agent/src/shared_learning/markdown_store.rs` | Save/load/list learnings as markdown with YAML frontmatter |
+| Domain model | `crates/terraphim_agent/src/shared_learning/types.rs` | `SharedLearning`, `TrustLevel`, `QualityMetrics`, source metadata |
+| CLI integration | `crates/terraphim_agent/src/main.rs` | `learn shared` subcommands call `SharedLearningStore` |
+| CLI integration tests | `crates/terraphim_agent/tests/shared_learning_cli_tests.rs` | Current behavioural coverage for list/import/promote/stats |
+| Prior plan | `.docs/design-learning-kg-2026-04-17.md` | Step 6 explicitly calls for replacing in-memory storage with markdown backend |
+
+### Data Flow
+
+Current:
+
+```text
+CLI -> SharedLearningStore::open()
+    -> DeviceStorage::arc_memory_only()
+    -> load_all() no-op
+    -> in-memory HashMap only
+
+Mutations -> persist() -> SharedLearningRecord.save()
+          -> no durable reads on next run
+```
+
+Desired:
+
+```text
+CLI -> SharedLearningStore::open()
+    -> MarkdownLearningStore backend
+    -> load persisted canonical learnings into in-memory index
+
+Mutations -> persist canonical markdown file
+Reads     -> serve from in-memory index after startup load
+```
+
+### Integration Points
+
+- `run_shared_learning_command()` in `main.rs` depends on `SharedLearningStore::open()` plus current list/get/promote/import APIs.
+- `LearningInjector` reads markdown files directly from the shared directory and should not be broken by canonical-store migration.
+- `wiki_sync` is related to shared learning publication but is not currently wired through `SharedLearningStore`.
+
+## Constraints
+
+### Technical Constraints
+
+- The public `SharedLearningStore` API is already used by the CLI and tests, so Step 6 should preserve those signatures where possible.
+- `SharedLearning` includes quality and metadata fields that the markdown backend does not yet persist.
+- `MarkdownLearningStore::list_all()` walks every subdirectory, including the shared directory, which can create duplicates if shared copies are treated as canonical records.
+- The repository guidance for this cluster explicitly prefers `ProjectDirs::from("com", "aks", "terraphim")` over ad hoc `dirs::data_local_dir()` usage.
+- Tests must not use mocks.
+
+### Business Constraints
+
+- This is Step 6 of an already approved sequence, so the safest option is to preserve behaviour and limit scope to store durability.
+- Human approval is required before implementation.
+
+### Non-Functional Requirements
+
+| Requirement | Target | Current |
+|-------------|--------|---------|
+| Durability across restart | Required | Not met |
+| CLI compatibility | Preserve | Currently present |
+| Startup cost | Acceptable for local file scan | Not applicable yet |
+| Human readability | Preserve markdown files | Already present in markdown backend |
+
+## Vital Few (Essentialism)
+
+### Essential Constraints (Max 3)
+
+| Constraint | Why It's Vital | Evidence |
+|------------|----------------|----------|
+| Preserve full `SharedLearning` fidelity | Losing quality/promotion metadata would silently break trust promotion and ranking behaviour | `types.rs` has richer fields than `markdown_store.rs` frontmatter |
+| Preserve current `SharedLearningStore` API | CLI and tests already depend on it | `main.rs` and `shared_learning_cli_tests.rs` call `open`, `insert`, `list_all`, `promote_*`, `get` |
+| Keep de-duplicated canonical state in memory even when loading shared publication artefacts | Shared copies may be present alongside canonical records, but the store index must still present one logical learning per ID | `MarkdownLearningStore::list_all()` currently traverses `shared/` as well as agent directories |
+
+### Eliminated from Scope
+
+| Eliminated Item | Why Eliminated |
+|-----------------|----------------|
+| Rewriting BM25 deduplication or ranking | Already works inside `SharedLearningStore`; durability does not require changing it |
+| Reworking injector logic | Step 6 is about store migration, not injection behaviour |
+| Introducing SQLite or another database | Conflicts with the markdown-first direction already approved |
+| Auto-publishing L2/L3 learnings to shared storage during this step | Changes behaviour and risks duplicate indexing; better handled separately |
+
+## Dependencies
+
+### Internal Dependencies
+
+| Dependency | Impact | Risk |
+|------------|--------|------|
+| `shared_learning/types.rs` | Defines the full payload that must round-trip | High |
+| `shared_learning/markdown_store.rs` | Primary backend candidate | High |
+| `main.rs` shared-learning CLI | Must keep working unchanged | Medium |
+| `.docs/research-cross-platform-data-dirs.md` | Defines the approved path direction | Medium |
+
+### External Dependencies
+
+| Dependency | Version | Risk | Alternative |
+|------------|---------|------|-------------|
+| `tokio::fs` | Existing | Low | None needed |
+| `serde_yaml` | Existing | Low | None needed |
+| `directories` crate or shared helper using it | Already used elsewhere in repo | Low | Keep `dirs`, but that conflicts with the approved path direction |
+
+## Risks and Unknowns
+
+### Known Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Partial frontmatter causes silent metadata loss | High | High | Expand frontmatter to cover all persisted `SharedLearning` fields and add restart round-trip tests |
+| Shared-directory files are indexed as duplicates | Medium | High | Load all markdown files, then de-duplicate by `learning.id`, preferring the non-shared path when both copies exist |
+| Path migration changes where files are stored | Medium | Medium | Keep `TERRAPHIM_LEARNINGS_DIR` override and support sparse old frontmatter when reading existing files |
+| Existing tests assume in-memory semantics | Medium | Medium | Move tests to temp-directory-backed durable stores and add restart coverage |
+
+### Open Questions
+
+1. Should Step 6 include a small helper for consistent Terraphim data paths, or is adding `directories` directly to `terraphim_agent` acceptable?
+2. Resolved during approval: read everything and de-duplicate by `learning.id`, preferring a non-shared path when both canonical and shared copies exist.
+
+### Assumptions Explicitly Stated
+
+| Assumption | Basis | Risk if Wrong | Verified? |
+|------------|-------|---------------|-----------|
+| Existing Step 1 markdown files may already exist with sparse frontmatter | `markdown_store.rs` already shipped with a reduced frontmatter schema | Old files could fail to load after migration if parsing becomes strict | Partially |
+| `SharedLearningStore` should remain the public API | CLI and integration tests already use it directly | Wider refactor than Step 6 if wrong | Yes |
+| When the same learning exists in both canonical and shared locations, the non-shared copy should win during load | Shared copies are distribution artefacts, while canonical files are the editable source of truth | Stale shared copy could override fresher canonical metadata if wrong | No |
+| We do not need a `terraphim_persistence` abstraction for Step 6 | The filesystem backend already exists and works; current persistence field is effectively dead code | Extra abstraction work if other code requires it later | Yes |
+
+### Multiple Interpretations Considered
+
+| Interpretation | Implications | Why Chosen/Rejected |
+|----------------|--------------|---------------------|
+| Replace `SharedLearningStore` entirely with `MarkdownLearningStore` | Simpler type graph, but forces CLI and algorithm rewrites | Rejected; too broad for Step 6 |
+| Keep `SharedLearningStore` and swap only the persistence backend | Preserves caller API and existing ranking logic | Chosen |
+| Persist canonical learnings and also auto-write to `shared/` on promotion | Useful later, but changes behaviour and risks duplicate reads | Rejected for this step |
+
+## Research Findings
+
+### Key Insights
+
+1. The real Step 6 problem is not "build a storage abstraction"; it is "remove fake durability without disturbing the higher-level store behaviour".
+2. The current markdown backend is close, but its frontmatter is incomplete relative to `SharedLearning`.
+3. The cleanest migration path is to delete the unused `DeviceStorage` dependency from `store.rs`, not add more abstraction on top of it.
+4. Canonical-store loading and shared-directory publication need separate concepts, even if both locations are loaded and then collapsed into one in-memory record per `learning.id`.
+
+### Relevant Prior Art
+
+- `crates/terraphim_orchestrator/src/learning.rs`: separates high-level store behaviour from persistence implementation; useful as a structural reference, even though the agent store can stay more minimal.
+- `.docs/research-cross-platform-data-dirs.md`: already recommends `ProjectDirs` for cross-platform local data.
+
+### Technical Spikes Needed
+
+No separate spike is required before implementation. The remaining work is design-level, not exploratory.
+
+## Recommendations
+
+### Proceed/No-Proceed
+
+Proceed.
+
+### Scope Recommendations
+
+- Keep `SharedLearningStore` as the public API.
+- Replace `DeviceStorage`/`SharedLearningRecord` usage in `store.rs` with `MarkdownLearningStore`.
+- Extend markdown frontmatter to persist the full `SharedLearning` state.
+- Load all markdown learning locations and de-duplicate by `learning.id` during startup hydration.
+- Align default paths with the `ProjectDirs` recommendation while preserving explicit environment override.
+
+### Risk Mitigation Recommendations
+
+- Add round-trip tests that verify `quality`, `keywords`, `applicable_agents`, `verify_pattern`, `promoted_at`, and `updated_at` survive restart.
+- Add a restart test for `SharedLearningStore` using a temp directory.
+- Keep backwards-compatible parsing for old sparse markdown files by making newly added frontmatter fields optional with safe defaults.
+
+## Next Steps
+
+If approved:
+
+1. Write the implementation plan for Step 6.
+2. Implement the markdown round-trip expansion and canonical loading changes.
+3. Run focused unit and integration tests for `shared-learning`.
+
+## Appendix
+
+### Reference Materials
+
+- `crates/terraphim_agent/src/shared_learning/store.rs`
+- `crates/terraphim_agent/src/shared_learning/markdown_store.rs`
+- `crates/terraphim_agent/src/shared_learning/types.rs`
+- `crates/terraphim_agent/tests/shared_learning_cli_tests.rs`
+- `.docs/design-learning-kg-2026-04-17.md`
+- `.docs/research-cross-platform-data-dirs.md`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,15 @@ dependencies = [
 
 [[package]]
 name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
@@ -8495,6 +8504,7 @@ dependencies = [
  "comfy-table",
  "crossterm",
  "dialoguer",
+ "directories 5.0.1",
  "dirs 5.0.1",
  "futures",
  "glob",
@@ -9228,7 +9238,7 @@ dependencies = [
 name = "terraphim_settings"
 version = "1.15.0"
 dependencies = [
- "directories",
+ "directories 6.0.0",
  "envtestkit",
  "log",
  "serde",

--- a/crates/terraphim_agent/Cargo.toml
+++ b/crates/terraphim_agent/Cargo.toml
@@ -64,6 +64,7 @@ rustyline = { version = "17.0", optional = true }
 colored = { version = "3.0", optional = true }
 comfy-table = { version = "7.0", optional = true }
 dirs = { version = "5.0" }
+directories = "5.0"
 terraphim_types = { path = "../terraphim_types", version = "1.0.0" }
 terraphim_settings = { path = "../terraphim_settings", version = "1.0.0" }
 terraphim_persistence = { path = "../terraphim_persistence", version = "1.0.0" }

--- a/crates/terraphim_agent/src/main.rs
+++ b/crates/terraphim_agent/src/main.rs
@@ -2868,11 +2868,6 @@ async fn run_shared_learning_command(
             }
             Ok(())
         }
-        #[cfg(not(feature = "cross-agent-injection"))]
-        SharedLearningSub::Inject { .. } => {
-            eprintln!("error: 'inject' requires the 'cross-agent-injection' feature");
-            std::process::exit(1);
-        }
     }
 }
 

--- a/crates/terraphim_agent/src/shared_learning/markdown_store.rs
+++ b/crates/terraphim_agent/src/shared_learning/markdown_store.rs
@@ -190,14 +190,33 @@ impl MarkdownLearningStore {
 
     /// List all learnings across all agents
     pub async fn list_all(&self) -> Result<Vec<SharedLearning>, MarkdownStoreError> {
+        let all_with_origin = self.list_all_with_origin().await?;
+        Ok(all_with_origin
+            .into_iter()
+            .map(|(_, learning)| learning)
+            .collect())
+    }
+
+    pub(crate) async fn list_all_with_origin(
+        &self,
+    ) -> Result<Vec<(bool, SharedLearning)>, MarkdownStoreError> {
         let mut all_learnings = Vec::new();
+
+        if !self.config.learnings_dir.exists() {
+            return Ok(all_learnings);
+        }
 
         let mut entries = tokio::fs::read_dir(&self.config.learnings_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
             if path.is_dir() {
-                let mut learnings = self.list_from_dir(&path).await?;
-                all_learnings.append(&mut learnings);
+                let is_shared = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name == self.config.shared_dir_name);
+
+                let learnings = self.list_from_dir(&path).await?;
+                all_learnings.extend(learnings.into_iter().map(|learning| (is_shared, learning)));
             }
         }
 
@@ -603,5 +622,20 @@ This is content from an old learning.
         let titles: Vec<String> = all.into_iter().map(|l| l.title).collect();
         assert!(titles.contains(&"Agent Learning".to_string()));
         assert!(titles.contains(&"Shared Learning".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_list_all_returns_empty_when_root_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let missing_root = temp_dir.path().join("does-not-exist");
+
+        let config = MarkdownStoreConfig {
+            learnings_dir: missing_root,
+            shared_dir_name: "shared".to_string(),
+        };
+        let store = MarkdownLearningStore::with_config(config);
+
+        let all = store.list_all().await.unwrap();
+        assert!(all.is_empty());
     }
 }

--- a/crates/terraphim_agent/src/shared_learning/markdown_store.rs
+++ b/crates/terraphim_agent/src/shared_learning/markdown_store.rs
@@ -7,11 +7,10 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use terraphim_types::Document;
 use thiserror::Error;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
-use crate::shared_learning::types::{LearningSource, SharedLearning, TrustLevel};
+use crate::shared_learning::types::{LearningSource, QualityMetrics, SharedLearning, TrustLevel};
 
 #[derive(Error, Debug)]
 pub enum MarkdownStoreError {
@@ -42,9 +41,9 @@ impl Default for MarkdownStoreConfig {
         let learnings_dir = std::env::var("TERRAPHIM_LEARNINGS_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| {
-                dirs::data_local_dir()
+                directories::ProjectDirs::from("com", "aks", "terraphim")
+                    .map(|pd| pd.data_local_dir().to_path_buf())
                     .unwrap_or_else(|| PathBuf::from("."))
-                    .join("terraphim")
                     .join("learnings")
             });
 
@@ -67,20 +66,29 @@ struct LearningFrontmatter {
     id: String,
     title: String,
     agent_id: String,
-    agent_name: String,
-    captured_at: String,
+    #[serde(default)]
+    captured_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+    #[serde(default)]
+    promoted_at: Option<String>,
     trust_level: String,
     source: String,
-    importance: f64,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    entities: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    applicable_agents: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    keywords: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    verify_pattern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    quality: Option<QualityMetrics>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     original_command: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     error_context: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     correction: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     wiki_page_name: Option<String>,
 }
 
@@ -226,12 +234,15 @@ impl MarkdownLearningStore {
             id: learning.id.clone(),
             title: learning.title.clone(),
             agent_id: learning.source_agent.clone(),
-            agent_name: learning.source_agent.clone(), // TODO: add agent_name field
-            captured_at: learning.created_at.to_rfc3339(),
+            captured_at: Some(learning.created_at.to_rfc3339()),
+            updated_at: Some(learning.updated_at.to_rfc3339()),
+            promoted_at: learning.promoted_at.map(|dt| dt.to_rfc3339()),
             trust_level: learning.trust_level.as_str().to_string(),
-            source: format!("{:?}", learning.source),
-            importance: 0.0,      // TODO: add importance field
-            entities: Vec::new(), // TODO: add entities field
+            source: Self::learning_source_to_string(&learning.source),
+            applicable_agents: learning.applicable_agents.clone(),
+            keywords: learning.keywords.clone(),
+            verify_pattern: learning.verify_pattern.clone(),
+            quality: Some(learning.quality.clone()),
             original_command: learning.original_command.clone(),
             error_context: learning.error_context.clone(),
             correction: learning.correction.clone(),
@@ -264,15 +275,7 @@ impl MarkdownLearningStore {
             MarkdownStoreError::InvalidFormat(format!("Invalid trust level: {}", e))
         })?;
 
-        let source = match frontmatter.source.as_str() {
-            "BashHook" => LearningSource::BashHook,
-            "AutoExtract" => LearningSource::AutoExtract,
-            "ToolHealth" => LearningSource::ToolHealth,
-            "GiteaComment" => LearningSource::GiteaComment,
-            "CjeVerdict" => LearningSource::CjeVerdict,
-            "Manual" => LearningSource::Manual,
-            _ => LearningSource::AutoExtract,
-        };
+        let source = Self::parse_learning_source(&frontmatter.source);
 
         let mut learning = SharedLearning::new(
             frontmatter.title,
@@ -285,15 +288,57 @@ impl MarkdownLearningStore {
         learning.trust_level = trust_level;
         learning.created_at = frontmatter
             .captured_at
-            .parse()
-            .unwrap_or_else(|_| Utc::now());
-        learning.updated_at = Utc::now();
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(Utc::now);
+        learning.updated_at = frontmatter
+            .updated_at
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(Utc::now);
+        learning.promoted_at = frontmatter.promoted_at.and_then(|s| s.parse().ok());
+        learning.applicable_agents = frontmatter.applicable_agents;
+        learning.keywords = frontmatter.keywords;
+        learning.verify_pattern = frontmatter.verify_pattern;
+        learning.quality = frontmatter.quality.unwrap_or_default();
         learning.original_command = frontmatter.original_command;
         learning.error_context = frontmatter.error_context;
         learning.correction = frontmatter.correction;
         learning.wiki_page_name = frontmatter.wiki_page_name;
 
         Ok(learning)
+    }
+
+    /// Convert a LearningSource to a snake_case string for frontmatter
+    fn learning_source_to_string(source: &LearningSource) -> String {
+        match source {
+            LearningSource::BashHook => "bash_hook",
+            LearningSource::AutoExtract => "auto_extract",
+            LearningSource::ToolHealth => "tool_health",
+            LearningSource::GiteaComment => "gitea_comment",
+            LearningSource::CjeVerdict => "cje_verdict",
+            LearningSource::Manual => "manual",
+        }
+        .to_string()
+    }
+
+    /// Parse a LearningSource from a string, supporting multiple formats
+    fn parse_learning_source(s: &str) -> LearningSource {
+        match s {
+            // snake_case (current format)
+            "bash_hook" => LearningSource::BashHook,
+            "auto_extract" => LearningSource::AutoExtract,
+            "tool_health" => LearningSource::ToolHealth,
+            "gitea_comment" => LearningSource::GiteaComment,
+            "cje_verdict" => LearningSource::CjeVerdict,
+            "manual" => LearningSource::Manual,
+            // PascalCase (legacy format from format!("{:?}"))
+            "BashHook" => LearningSource::BashHook,
+            "AutoExtract" => LearningSource::AutoExtract,
+            "ToolHealth" => LearningSource::ToolHealth,
+            "GiteaComment" => LearningSource::GiteaComment,
+            "CjeVerdict" => LearningSource::CjeVerdict,
+            "Manual" => LearningSource::Manual,
+            _ => LearningSource::AutoExtract,
+        }
     }
 
     /// Helper to list learnings from a directory
@@ -404,5 +449,159 @@ mod tests {
         let shared = store.list_shared().await.unwrap();
         assert_eq!(shared.len(), 1);
         assert_eq!(shared[0].title, "Shared Learning");
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_roundtrip_preserves_full_state() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = MarkdownStoreConfig {
+            learnings_dir: temp_dir.path().to_path_buf(),
+            shared_dir_name: "shared".to_string(),
+        };
+        let store = MarkdownLearningStore::with_config(config);
+
+        let mut learning = SharedLearning::new(
+            "Full State Learning".to_string(),
+            "This is the body.".to_string(),
+            LearningSource::BashHook,
+            "test-agent".to_string(),
+        );
+        learning.id = "custom-id-123".to_string();
+        learning.trust_level = TrustLevel::L2;
+        learning.created_at = "2024-01-15T10:30:00Z".parse().unwrap();
+        learning.updated_at = "2024-06-20T14:45:00Z".parse().unwrap();
+        learning.promoted_at = Some("2024-06-20T14:45:00Z".parse().unwrap());
+        learning.applicable_agents = vec!["security-audit".to_string(), "code-review".to_string()];
+        learning.keywords = vec!["git".to_string(), "force-push".to_string()];
+        learning.verify_pattern = Some("git push --force-with-lease".to_string());
+        learning.quality.applied_count = 5;
+        learning.quality.effective_count = 4;
+        learning.quality.agent_count = 3;
+        learning.quality.agent_names = vec![
+            "agent1".to_string(),
+            "agent2".to_string(),
+            "agent3".to_string(),
+        ];
+        learning.quality.last_applied_at = Some("2024-06-19T12:00:00Z".parse().unwrap());
+        learning.quality.success_rate = Some(0.8);
+        learning.original_command = Some("git push -f".to_string());
+        learning.error_context = Some("rejected".to_string());
+        learning.correction = Some("use --force-with-lease".to_string());
+        learning.wiki_page_name = Some("learning-git-push".to_string());
+
+        store.save(&learning).await.unwrap();
+        let loaded = store.load("test-agent", &learning.id).await.unwrap();
+
+        assert_eq!(loaded.id, learning.id);
+        assert_eq!(loaded.title, learning.title);
+        assert_eq!(loaded.content, learning.content);
+        assert_eq!(loaded.source_agent, learning.source_agent);
+        assert_eq!(loaded.trust_level, learning.trust_level);
+        assert_eq!(loaded.source, learning.source);
+        assert_eq!(loaded.created_at, learning.created_at);
+        assert_eq!(loaded.updated_at, learning.updated_at);
+        assert_eq!(loaded.promoted_at, learning.promoted_at);
+        assert_eq!(loaded.applicable_agents, learning.applicable_agents);
+        assert_eq!(loaded.keywords, learning.keywords);
+        assert_eq!(loaded.verify_pattern, learning.verify_pattern);
+        assert_eq!(loaded.quality.applied_count, learning.quality.applied_count);
+        assert_eq!(
+            loaded.quality.effective_count,
+            learning.quality.effective_count
+        );
+        assert_eq!(loaded.quality.agent_count, learning.quality.agent_count);
+        assert_eq!(loaded.quality.agent_names, learning.quality.agent_names);
+        assert_eq!(
+            loaded.quality.last_applied_at,
+            learning.quality.last_applied_at
+        );
+        assert_eq!(loaded.quality.success_rate, learning.quality.success_rate);
+        assert_eq!(loaded.original_command, learning.original_command);
+        assert_eq!(loaded.error_context, learning.error_context);
+        assert_eq!(loaded.correction, learning.correction);
+        assert_eq!(loaded.wiki_page_name, learning.wiki_page_name);
+    }
+
+    #[tokio::test]
+    async fn test_sparse_old_frontmatter_still_loads() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = MarkdownStoreConfig {
+            learnings_dir: temp_dir.path().to_path_buf(),
+            shared_dir_name: "shared".to_string(),
+        };
+        let store = MarkdownLearningStore::with_config(config);
+
+        // Create a markdown file with only the old sparse frontmatter
+        let sparse_content = r#"---
+id: old-learning-456
+title: Old Sparse Learning
+agent_id: legacy-agent
+captured_at: "2024-03-10T08:00:00Z"
+trust_level: L3
+source: Manual
+---
+
+This is content from an old learning.
+"#;
+
+        let agent_dir = store.agent_dir("legacy-agent");
+        tokio::fs::create_dir_all(&agent_dir).await.unwrap();
+        let file_path = agent_dir.join("old-learning-456.md");
+        tokio::fs::write(&file_path, sparse_content).await.unwrap();
+
+        let loaded = store
+            .load("legacy-agent", "old-learning-456")
+            .await
+            .unwrap();
+
+        assert_eq!(loaded.id, "old-learning-456");
+        assert_eq!(loaded.title, "Old Sparse Learning");
+        assert_eq!(loaded.source_agent, "legacy-agent");
+        assert_eq!(loaded.trust_level, TrustLevel::L3);
+        assert_eq!(loaded.source, LearningSource::Manual);
+        assert_eq!(loaded.content, "This is content from an old learning.");
+        // Missing fields should have safe defaults
+        assert!(loaded.applicable_agents.is_empty());
+        assert!(loaded.keywords.is_empty());
+        assert!(loaded.verify_pattern.is_none());
+        assert_eq!(loaded.quality.applied_count, 0);
+        assert!(loaded.original_command.is_none());
+        assert!(loaded.error_context.is_none());
+        assert!(loaded.correction.is_none());
+        assert!(loaded.wiki_page_name.is_none());
+        assert!(loaded.promoted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_all_supports_dedup_inputs() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = MarkdownStoreConfig {
+            learnings_dir: temp_dir.path().to_path_buf(),
+            shared_dir_name: "shared".to_string(),
+        };
+        let store = MarkdownLearningStore::with_config(config);
+
+        let learning1 = SharedLearning::new(
+            "Agent Learning".to_string(),
+            "Body from agent.".to_string(),
+            LearningSource::AutoExtract,
+            "agent-a".to_string(),
+        );
+
+        let learning2 = SharedLearning::new(
+            "Shared Learning".to_string(),
+            "Body from shared.".to_string(),
+            LearningSource::Manual,
+            "agent-b".to_string(),
+        );
+
+        store.save(&learning1).await.unwrap();
+        store.save_to_shared(&learning2).await.unwrap();
+
+        let all = store.list_all().await.unwrap();
+        assert_eq!(all.len(), 2);
+        let titles: Vec<String> = all.into_iter().map(|l| l.title).collect();
+        assert!(titles.contains(&"Agent Learning".to_string()));
+        assert!(titles.contains(&"Shared Learning".to_string()));
     }
 }

--- a/crates/terraphim_agent/src/shared_learning/store.rs
+++ b/crates/terraphim_agent/src/shared_learning/store.rs
@@ -165,21 +165,34 @@ impl SharedLearningStore {
 
     async fn load_all(&self) -> Result<(), StoreError> {
         info!("Loading shared learnings from markdown backend");
-        let all_learnings = self.backend.list_all().await?;
-        let count = all_learnings.len();
+        let all_learnings = self.backend.list_all_with_origin().await?;
+        let discovered = all_learnings.len();
+
+        let mut selected: HashMap<String, (bool, SharedLearning)> = HashMap::new();
+        for (is_shared, learning) in all_learnings {
+            match selected.get(&learning.id) {
+                None => {
+                    selected.insert(learning.id.clone(), (is_shared, learning));
+                }
+                Some((existing_is_shared, _)) => {
+                    if *existing_is_shared && !is_shared {
+                        selected.insert(learning.id.clone(), (is_shared, learning));
+                    }
+                }
+            }
+        }
 
         let mut index = self.index.write().await;
-        for learning in all_learnings {
-            // Simple last-write-wins deduplication. Since list_all() doesn't return
-            // path metadata, we can't prefer canonical over shared copies.
-            // Filesystem order typically lists agent directories before shared,
-            // so canonical copies are usually first. This is a known limitation
-            // that can be improved when list_all() returns path metadata.
+        for (_, learning) in selected.into_values() {
             index.insert(learning.id.clone(), learning);
         }
+        let loaded = index.len();
         drop(index);
 
-        info!("Loaded {} shared learnings into index", count);
+        info!(
+            "Loaded {} shared learnings into index ({} discovered)",
+            loaded, discovered
+        );
         Ok(())
     }
 
@@ -733,8 +746,13 @@ mod tests {
 
         // Save to agent directory (canonical)
         backend.save(&learning).await.unwrap();
-        // Save to shared directory
-        backend.save_to_shared(&learning).await.unwrap();
+
+        // Save a stale variant to shared directory with same ID.
+        // Canonical should win after hydration.
+        let mut stale_shared_copy = learning.clone();
+        stale_shared_copy.title = "Stale Shared Copy".to_string();
+        stale_shared_copy.trust_level = TrustLevel::L1;
+        backend.save_to_shared(&stale_shared_copy).await.unwrap();
 
         // Now open the store - it should deduplicate
         let config = StoreConfig::default()
@@ -746,6 +764,7 @@ mod tests {
         // Should only have 1 entry despite 2 files on disk
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].id, "dedup-test-id");
+        assert_eq!(all[0].title, "Shared Dedup Test");
     }
 
     #[tokio::test]

--- a/crates/terraphim_agent/src/shared_learning/store.rs
+++ b/crates/terraphim_agent/src/shared_learning/store.rs
@@ -1,18 +1,19 @@
 //! Shared learning store implementation
 //!
-//! Provides terraphim_persistence-backed storage with BM25-based deduplication
+//! Provides markdown-backed storage with BM25-based deduplication
 //! and trust-gated promotion logic.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use chrono::Utc;
-use terraphim_persistence::{DeviceStorage, Persistable};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
 
-use crate::shared_learning::types::{LearningSource, SharedLearning, TrustLevel};
+use crate::shared_learning::markdown_store::{
+    MarkdownLearningStore, MarkdownStoreConfig, MarkdownStoreError,
+};
+use crate::shared_learning::types::{SharedLearning, TrustLevel};
 
 #[derive(Error, Debug)]
 pub enum StoreError {
@@ -28,8 +29,8 @@ pub enum StoreError {
     Serialization(#[from] serde_json::Error),
 }
 
-impl From<terraphim_persistence::Error> for StoreError {
-    fn from(e: terraphim_persistence::Error) -> Self {
+impl From<MarkdownStoreError> for StoreError {
+    fn from(e: MarkdownStoreError) -> Self {
         StoreError::Persistence(e.to_string())
     }
 }
@@ -38,6 +39,7 @@ impl From<terraphim_persistence::Error> for StoreError {
 pub struct StoreConfig {
     pub similarity_threshold: f64,
     pub auto_promote_l2: bool,
+    pub markdown: MarkdownStoreConfig,
 }
 
 impl Default for StoreConfig {
@@ -45,6 +47,7 @@ impl Default for StoreConfig {
         Self {
             similarity_threshold: 0.8,
             auto_promote_l2: true,
+            markdown: MarkdownStoreConfig::default(),
         }
     }
 }
@@ -54,45 +57,10 @@ impl StoreConfig {
         self.similarity_threshold = threshold.clamp(0.0, 1.0);
         self
     }
-}
 
-/// Persistable record wrapper for SharedLearning.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct SharedLearningRecord {
-    pub key: String,
-    pub learning: SharedLearning,
-}
-
-#[async_trait::async_trait]
-impl Persistable for SharedLearningRecord {
-    fn new(key: String) -> Self {
-        Self {
-            key,
-            learning: SharedLearning::new(
-                String::new(),
-                String::new(),
-                LearningSource::Manual,
-                String::new(),
-            ),
-        }
-    }
-
-    async fn save(&self) -> terraphim_persistence::Result<()> {
-        self.save_to_all().await
-    }
-
-    async fn save_to_one(&self, profile_name: &str) -> terraphim_persistence::Result<()> {
-        self.save_to_profile(profile_name).await
-    }
-
-    async fn load(&mut self) -> terraphim_persistence::Result<Self> {
-        let key = self.get_key();
-        self.load_from_operator(&key, &self.load_config().await?.1)
-            .await
-    }
-
-    fn get_key(&self) -> String {
-        format!("shared-learning/{}.json", &self.key)
+    pub fn with_markdown_config(mut self, config: MarkdownStoreConfig) -> Self {
+        self.markdown = config;
+        self
     }
 }
 
@@ -177,18 +145,17 @@ impl Bm25Scorer {
     }
 }
 
-#[allow(dead_code)]
 pub struct SharedLearningStore {
-    storage: Arc<DeviceStorage>,
+    backend: MarkdownLearningStore,
     index: RwLock<HashMap<String, SharedLearning>>,
     config: StoreConfig,
 }
 
 impl SharedLearningStore {
     pub async fn open(config: StoreConfig) -> Result<Self, StoreError> {
-        let storage = DeviceStorage::arc_memory_only().await?;
+        let backend = MarkdownLearningStore::with_config(config.markdown.clone());
         let store = Self {
-            storage,
+            backend,
             index: RwLock::new(HashMap::new()),
             config,
         };
@@ -197,16 +164,27 @@ impl SharedLearningStore {
     }
 
     async fn load_all(&self) -> Result<(), StoreError> {
-        info!("Loading shared learnings from persistence");
+        info!("Loading shared learnings from markdown backend");
+        let all_learnings = self.backend.list_all().await?;
+        let count = all_learnings.len();
+
+        let mut index = self.index.write().await;
+        for learning in all_learnings {
+            // Simple last-write-wins deduplication. Since list_all() doesn't return
+            // path metadata, we can't prefer canonical over shared copies.
+            // Filesystem order typically lists agent directories before shared,
+            // so canonical copies are usually first. This is a known limitation
+            // that can be improved when list_all() returns path metadata.
+            index.insert(learning.id.clone(), learning);
+        }
+        drop(index);
+
+        info!("Loaded {} shared learnings into index", count);
         Ok(())
     }
 
     async fn persist(&self, learning: &SharedLearning) -> Result<(), StoreError> {
-        let record = SharedLearningRecord {
-            key: learning.id.clone(),
-            learning: learning.clone(),
-        };
-        record.save().await?;
+        self.backend.save(learning).await?;
         Ok(())
     }
 
@@ -517,9 +495,18 @@ pub enum StoreResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shared_learning::types::LearningSource;
+    use tempfile::TempDir;
 
     async fn create_test_store() -> SharedLearningStore {
-        let config = StoreConfig::default().with_similarity_threshold(0.3);
+        let temp_dir = TempDir::new().unwrap();
+        let markdown_config = MarkdownStoreConfig {
+            learnings_dir: temp_dir.path().to_path_buf(),
+            shared_dir_name: "shared".to_string(),
+        };
+        let config = StoreConfig::default()
+            .with_similarity_threshold(0.3)
+            .with_markdown_config(markdown_config);
         SharedLearningStore::open(config).await.unwrap()
     }
 
@@ -680,5 +667,129 @@ mod tests {
 
         let retrieved = store.get(&id).await.unwrap();
         assert_eq!(retrieved.trust_level, TrustLevel::L2);
+    }
+
+    #[tokio::test]
+    async fn test_open_loads_existing_markdown_learnings() {
+        // Create a temp dir and directly save learnings via the markdown backend
+        let temp_dir = TempDir::new().unwrap();
+        let markdown_config = MarkdownStoreConfig {
+            learnings_dir: temp_dir.path().to_path_buf(),
+            shared_dir_name: "shared".to_string(),
+        };
+        let backend = MarkdownLearningStore::with_config(markdown_config.clone());
+
+        let learning1 = SharedLearning::new(
+            "Pre-existing Learning".to_string(),
+            "This learning was saved before the store opened.".to_string(),
+            LearningSource::AutoExtract,
+            "test-agent".to_string(),
+        );
+        let id1 = learning1.id.clone();
+        backend.save(&learning1).await.unwrap();
+
+        let learning2 = SharedLearning::new(
+            "Another Pre-existing".to_string(),
+            "Also saved before open.".to_string(),
+            LearningSource::Manual,
+            "other-agent".to_string(),
+        );
+        let id2 = learning2.id.clone();
+        backend.save(&learning2).await.unwrap();
+
+        // Now open the store - it should load existing learnings
+        let config = StoreConfig::default()
+            .with_similarity_threshold(0.3)
+            .with_markdown_config(markdown_config);
+        let store = SharedLearningStore::open(config).await.unwrap();
+
+        let all = store.list_all().await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        let retrieved1 = store.get(&id1).await.unwrap();
+        assert_eq!(retrieved1.title, "Pre-existing Learning");
+
+        let retrieved2 = store.get(&id2).await.unwrap();
+        assert_eq!(retrieved2.title, "Another Pre-existing");
+    }
+
+    #[tokio::test]
+    async fn test_open_dedups_shared_and_canonical_copies() {
+        // Create a temp dir and save the same learning to both agent dir and shared dir
+        let temp_dir = TempDir::new().unwrap();
+        let markdown_config = MarkdownStoreConfig {
+            learnings_dir: temp_dir.path().to_path_buf(),
+            shared_dir_name: "shared".to_string(),
+        };
+        let backend = MarkdownLearningStore::with_config(markdown_config.clone());
+
+        let mut learning = SharedLearning::new(
+            "Shared Dedup Test".to_string(),
+            "Testing deduplication.".to_string(),
+            LearningSource::AutoExtract,
+            "agent-x".to_string(),
+        );
+        learning.id = "dedup-test-id".to_string();
+
+        // Save to agent directory (canonical)
+        backend.save(&learning).await.unwrap();
+        // Save to shared directory
+        backend.save_to_shared(&learning).await.unwrap();
+
+        // Now open the store - it should deduplicate
+        let config = StoreConfig::default()
+            .with_similarity_threshold(0.3)
+            .with_markdown_config(markdown_config);
+        let store = SharedLearningStore::open(config).await.unwrap();
+
+        let all = store.list_all().await.unwrap();
+        // Should only have 1 entry despite 2 files on disk
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, "dedup-test-id");
+    }
+
+    #[tokio::test]
+    async fn test_persist_after_promotion_and_application() {
+        let temp_dir = TempDir::new().unwrap();
+        let markdown_config = MarkdownStoreConfig {
+            learnings_dir: temp_dir.path().to_path_buf(),
+            shared_dir_name: "shared".to_string(),
+        };
+        let config = StoreConfig::default()
+            .with_similarity_threshold(0.3)
+            .with_markdown_config(markdown_config.clone());
+
+        let store = SharedLearningStore::open(config).await.unwrap();
+
+        let learning = SharedLearning::new(
+            "Persist Test".to_string(),
+            "Testing persistence.".to_string(),
+            LearningSource::Manual,
+            "test-agent".to_string(),
+        );
+        let id = learning.id.clone();
+        store.insert(learning).await.unwrap();
+
+        // Promote to L2
+        store.promote_to_l2(&id).await.unwrap();
+
+        // Record applications
+        store.record_application(&id, "agent1", true).await.unwrap();
+        store.record_application(&id, "agent2", true).await.unwrap();
+
+        // Close and reopen the store
+        store.close().await;
+
+        let config2 = StoreConfig::default()
+            .with_similarity_threshold(0.3)
+            .with_markdown_config(markdown_config);
+        let reopened = SharedLearningStore::open(config2).await.unwrap();
+
+        let retrieved = reopened.get(&id).await.unwrap();
+        assert_eq!(retrieved.trust_level, TrustLevel::L2);
+        assert_eq!(retrieved.quality.applied_count, 2);
+        assert_eq!(retrieved.quality.effective_count, 2);
+        assert_eq!(retrieved.quality.agent_count, 2);
+        assert!(retrieved.promoted_at.is_some());
     }
 }

--- a/crates/terraphim_agent/tests/shared_learning_cli_tests.rs
+++ b/crates/terraphim_agent/tests/shared_learning_cli_tests.rs
@@ -6,13 +6,25 @@
 #![cfg(feature = "shared-learning")]
 
 use terraphim_agent::shared_learning::{
-    SharedLearning, SharedLearningSource, SharedLearningStore, StoreConfig, TrustLevel,
+    MarkdownStoreConfig, SharedLearning, SharedLearningSource, SharedLearningStore, StoreConfig,
+    TrustLevel,
 };
 
 async fn create_store() -> SharedLearningStore {
-    SharedLearningStore::open(StoreConfig::default())
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.keep();
+    let markdown_config = MarkdownStoreConfig {
+        learnings_dir: path,
+        shared_dir_name: "shared".to_string(),
+    };
+    let store_config = StoreConfig {
+        similarity_threshold: 0.8,
+        auto_promote_l2: true,
+        markdown: markdown_config,
+    };
+    SharedLearningStore::open(store_config)
         .await
-        .expect("should open in-memory store")
+        .expect("should open store")
 }
 
 #[tokio::test]
@@ -191,4 +203,125 @@ async fn shared_trust_level_parse() {
     assert_eq!("L2".parse::<TrustLevel>().unwrap(), TrustLevel::L2);
     assert_eq!("l3".parse::<TrustLevel>().unwrap(), TrustLevel::L3);
     assert!("invalid".parse::<TrustLevel>().is_err());
+}
+
+#[tokio::test]
+async fn shared_store_survives_restart() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let markdown_config = MarkdownStoreConfig {
+        learnings_dir: temp_dir.path().to_path_buf(),
+        shared_dir_name: "shared".to_string(),
+    };
+
+    // 1. Create a store with temp dir config
+    let store_config = StoreConfig {
+        similarity_threshold: 0.8,
+        auto_promote_l2: true,
+        markdown: markdown_config.clone(),
+    };
+    let store = SharedLearningStore::open(store_config)
+        .await
+        .expect("should open store");
+
+    // 2. Insert a learning with quality metrics
+    let mut learning = SharedLearning::new(
+        "Restart Test".to_string(),
+        "Testing restart persistence.".to_string(),
+        SharedLearningSource::Manual,
+        "test-agent".to_string(),
+    );
+    learning.quality.applied_count = 3;
+    learning.quality.effective_count = 3;
+    learning.quality.agent_names = vec!["agent1".to_string(), "agent2".to_string()];
+    let id = learning.id.clone();
+    store.insert(learning).await.expect("insert");
+
+    // 3. Promote it to L2
+    store.promote_to_l2(&id).await.expect("promote to l2");
+
+    // 4. Drop the store (simulating process exit)
+    drop(store);
+
+    // 5. Create a NEW store with the SAME temp dir config
+    let store_config2 = StoreConfig {
+        similarity_threshold: 0.8,
+        auto_promote_l2: true,
+        markdown: markdown_config,
+    };
+    let reopened = SharedLearningStore::open(store_config2)
+        .await
+        .expect("should reopen store");
+
+    // 6. Verify the learning is still there with correct trust level
+    let retrieved = reopened.get(&id).await.expect("get after reopen");
+    assert_eq!(retrieved.trust_level, TrustLevel::L2);
+    assert_eq!(retrieved.title, "Restart Test");
+    assert!(retrieved.promoted_at.is_some());
+
+    // 7. Verify quality metrics were preserved
+    assert_eq!(retrieved.quality.applied_count, 3);
+    assert_eq!(retrieved.quality.effective_count, 3);
+    assert_eq!(retrieved.quality.agent_names.len(), 2);
+}
+
+#[tokio::test]
+async fn shared_store_dedups_on_restart() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let markdown_config = MarkdownStoreConfig {
+        learnings_dir: temp_dir.path().to_path_buf(),
+        shared_dir_name: "shared".to_string(),
+    };
+
+    // 1. Create store with temp dir
+    let store_config = StoreConfig {
+        similarity_threshold: 0.8,
+        auto_promote_l2: true,
+        markdown: markdown_config.clone(),
+    };
+    let store = SharedLearningStore::open(store_config)
+        .await
+        .expect("should open store");
+
+    // 2. Insert a learning
+    let learning = SharedLearning::new(
+        "Dedup Test".to_string(),
+        "Testing deduplication on restart.".to_string(),
+        SharedLearningSource::Manual,
+        "test-agent".to_string(),
+    );
+    let id = learning.id.clone();
+    store.insert(learning).await.expect("insert");
+
+    // 3. Manually copy the markdown file to the shared directory
+    let canonical_path = temp_dir
+        .path()
+        .join("test-agent")
+        .join(format!("{}.md", id));
+    let shared_dir = temp_dir.path().join("shared");
+    tokio::fs::create_dir_all(&shared_dir).await.unwrap();
+    let shared_path = shared_dir.join(format!("test-agent-{}.md", id));
+    tokio::fs::copy(&canonical_path, &shared_path)
+        .await
+        .expect("copy to shared dir");
+
+    // 4. Drop and reopen store
+    drop(store);
+
+    let store_config2 = StoreConfig {
+        similarity_threshold: 0.8,
+        auto_promote_l2: true,
+        markdown: markdown_config,
+    };
+    let reopened = SharedLearningStore::open(store_config2)
+        .await
+        .expect("should reopen store");
+
+    // 5. Verify only one copy exists in the store index
+    let all = reopened.list_all().await.expect("list_all");
+    assert_eq!(
+        all.len(),
+        1,
+        "should deduplicate canonical and shared copies"
+    );
+    assert_eq!(all[0].id, id);
 }

--- a/crates/terraphim_sessions/src/connector/aider.rs
+++ b/crates/terraphim_sessions/src/connector/aider.rs
@@ -133,8 +133,7 @@ impl AiderConnector {
                     .and_then(|m| m.modified())
                     .ok()
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|d| DateTime::from_timestamp(d.as_secs() as i64, 0))
-                    .flatten()
+                    .and_then(|d| DateTime::from_timestamp(d.as_secs() as i64, 0))
                     .unwrap_or_else(Utc::now)
             });
 


### PR DESCRIPTION
## Summary
- migrate `SharedLearningStore` from in-memory persistence to `MarkdownLearningStore` with startup hydration from persisted markdown files
- expand markdown frontmatter round-tripping to preserve full `SharedLearning` state, including quality metrics, promotion metadata, and compatibility with older sparse files
- harden startup behaviour by treating missing root directories as empty stores and preferring canonical agent copies over shared replicas during ID collisions

## Testing
- cargo fmt -- --check
- cargo clippy -p terraphim_agent --lib --features shared-learning -- -D warnings
- cargo test -p terraphim_agent --lib
- cargo test -p terraphim_agent --test shared_learning_cli_tests --features shared-learning