### PR TITLE
feat(sessions): implement SessionConnector::watch() for real-time session ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9000,6 +9000,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "jiff",
+ "notify 8.2.0",
  "regex",
  "serde",
  "serde_json",

--- a/crates/terraphim_sessions/Cargo.toml
+++ b/crates/terraphim_sessions/Cargo.toml
@@ -58,6 +58,9 @@ jiff = { version = "0.2", features = ["serde"] }
 walkdir = "2.4"
 dirs = "5.0"
 
+# File watching
+notify = "8.2"
+
 # Feature-gated: regex for Aider/Cline connectors
 regex = { version = "1.10", optional = true }
 

--- a/crates/terraphim_sessions/src/connector/mod.rs
+++ b/crates/terraphim_sessions/src/connector/mod.rs
@@ -23,6 +23,7 @@ use crate::model::Session;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::path::PathBuf;
+use tokio::sync::mpsc;
 
 /// Status of a connector's detection
 #[derive(Debug, Clone)]
@@ -102,6 +103,19 @@ pub trait SessionConnector: Send + Sync {
 
     /// Import sessions from this source
     async fn import(&self, options: &ImportOptions) -> Result<Vec<Session>>;
+
+    /// Check if this connector supports real-time watching
+    fn supports_watch(&self) -> bool {
+        false
+    }
+
+    /// Start watching for new sessions in real-time
+    ///
+    /// Returns a receiver that emits sessions as they are detected.
+    /// Default implementation returns an error if not supported.
+    async fn watch(&self) -> Result<mpsc::Receiver<Session>> {
+        anyhow::bail!("Watch not supported for this connector")
+    }
 }
 
 /// Registry of available connectors
@@ -212,6 +226,33 @@ impl ConnectorRegistry {
 
         tracing::info!("Total sessions imported: {}", all_sessions.len());
         Ok(all_sessions)
+    }
+
+    /// Start watching all connectors that support watching
+    ///
+    /// Returns a vector of receivers that emit sessions as they are detected.
+    pub async fn watch_all(&self) -> Vec<mpsc::Receiver<Session>> {
+        let mut receivers = Vec::new();
+
+        for connector in self.connectors() {
+            if connector.supports_watch() {
+                match connector.watch().await {
+                    Ok(rx) => {
+                        tracing::info!("Watching: {}", connector.display_name());
+                        receivers.push(rx);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to start watch for {}: {}",
+                            connector.display_name(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        receivers
     }
 }
 

--- a/crates/terraphim_sessions/src/connector/native.rs
+++ b/crates/terraphim_sessions/src/connector/native.rs
@@ -7,8 +7,11 @@ use super::{ConnectorStatus, ImportOptions, SessionConnector};
 use crate::model::{ContentBlock, Message, MessageRole, Session, SessionMetadata};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use notify::{Event, EventKind, RecursiveMode, Watcher, recommended_watcher};
 use serde::Deserialize;
 use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::mpsc;
 
 /// Native Claude Code session connector
 #[derive(Debug, Default)]
@@ -115,6 +118,85 @@ impl SessionConnector for NativeClaudeConnector {
             total
         );
         Ok(sessions)
+    }
+
+    fn supports_watch(&self) -> bool {
+        true
+    }
+
+    async fn watch(&self) -> Result<mpsc::Receiver<Session>> {
+        let (tx, rx) = mpsc::channel(32);
+        let base_path = self
+            .default_path()
+            .ok_or_else(|| anyhow::anyhow!("No default path found for watch"))?;
+
+        if !base_path.exists() {
+            anyhow::bail!("Watch path does not exist: {}", base_path.display());
+        }
+
+        let path = Arc::new(base_path);
+
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let (watcher_tx, watcher_rx) = std::sync::mpsc::channel();
+            let mut watcher = recommended_watcher(move |res| {
+                let _ = watcher_tx.send(res);
+            })?;
+
+            watcher.watch(&path, RecursiveMode::Recursive)?;
+
+            tracing::info!(
+                "Started watching for Claude sessions in: {}",
+                path.display()
+            );
+
+            for res in watcher_rx {
+                match res {
+                    Ok(event) => {
+                        if let Event {
+                            kind: EventKind::Create(_) | EventKind::Modify(_),
+                            paths,
+                            ..
+                        } = event
+                        {
+                            for path in paths {
+                                if path.extension().is_some_and(|ext| ext == "jsonl") {
+                                    let tx = tx.clone();
+                                    let path_clone = path.clone();
+
+                                    tokio::spawn(async move {
+                                        let connector = NativeClaudeConnector;
+                                        match connector.parse_session_file(&path_clone).await {
+                                            Ok(Some(session)) => {
+                                                if tx.send(session).await.is_err() {
+                                                    tracing::warn!(
+                                                        "Failed to send session from watch"
+                                                    );
+                                                }
+                                            }
+                                            Ok(None) => {}
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    "Failed to parse new session {}: {}",
+                                                    path_clone.display(),
+                                                    e
+                                                );
+                                            }
+                                        }
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("Watch error: {}", e);
+                    }
+                }
+            }
+
+            Ok(())
+        });
+
+        Ok(rx)
     }
 }
 
@@ -476,5 +558,11 @@ mod tests {
             .with_limit(2);
         let sessions = connector.import(&options).await.unwrap();
         assert_eq!(sessions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_supports_watch() {
+        let connector = NativeClaudeConnector;
+        assert!(connector.supports_watch());
     }
 }


### PR DESCRIPTION
## Summary
- Added `watch()` method to `SessionConnector` trait for real-time session ingestion
- Implemented `watch()` for `NativeClaudeConnector` using `notify` crate
- Added `supports_watch()` method with default `false` implementation
- Added `watch_all()` method to `ConnectorRegistry` for watching all supported connectors

## Changes
- `crates/terraphim_sessions/src/connector/mod.rs`: Added `watch()` and `supports_watch()` to trait, added `watch_all()` to registry
- `crates/terraphim_sessions/src/connector/native.rs`: Implemented `watch()` with filesystem watching via `notify` crate
- `crates/terraphim_sessions/Cargo.toml`: Added `notify = "8.2"` dependency

## Testing
- All 53 tests pass
- Added test for `supports_watch()`

## Refs
Fixes #789