### PR TITLE
test(agent): Phase 1 unit, property-based, and integration tests

### DIFF
--- a/crates/terraphim_agent/Cargo.toml
+++ b/crates/terraphim_agent/Cargo.toml
@@ -82,6 +82,7 @@ terraphim_orchestrator = { path = "../terraphim_orchestrator", version = "1.0.0"
 terraphim_sessions = { path = "../terraphim_sessions", version = "1.6.0", optional = true, features = ["tsa-full", "aider-connector", "search-index"] }
 
 [dev-dependencies]
+proptest = "1"
 serial_test = "3.3"
 futures = "0.3"
 portpicker = "0.1"

--- a/crates/terraphim_agent/src/forgiving/aliases.rs
+++ b/crates/terraphim_agent/src/forgiving/aliases.rs
@@ -180,4 +180,99 @@ mod tests {
         // Original aliases preserved
         assert_eq!(base.expand("q"), Some("search"));
     }
+
+    #[test]
+    fn test_empty_registry() {
+        let registry = AliasRegistry::empty();
+        assert!(registry.expand("q").is_none());
+        assert!(!registry.is_alias("q"));
+        assert!(registry.all().is_empty());
+    }
+
+    #[test]
+    fn test_remove_alias() {
+        let mut registry = AliasRegistry::new();
+        assert_eq!(registry.expand("q"), Some("search"));
+        let removed = registry.remove("q");
+        assert_eq!(removed, Some("search".to_string()));
+        assert!(registry.expand("q").is_none());
+    }
+
+    #[test]
+    fn test_remove_nonexistent() {
+        let mut registry = AliasRegistry::new();
+        assert!(registry.remove("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_is_alias() {
+        let registry = AliasRegistry::new();
+        assert!(registry.is_alias("q"));
+        assert!(registry.is_alias("?"));
+        assert!(!registry.is_alias("search"));
+        assert!(!registry.is_alias(""));
+    }
+
+    #[test]
+    fn test_add_duplicate_overwrites() {
+        let mut registry = AliasRegistry::empty();
+        registry.add("x", "cmd_a");
+        registry.add("x", "cmd_b");
+        assert_eq!(registry.expand("x"), Some("cmd_b"));
+    }
+
+    #[test]
+    fn test_from_config_whitespace_lines() {
+        let config = "\n\n  \n# comment\n";
+        let registry = AliasRegistry::from_config(config).unwrap();
+        assert!(registry.all().is_empty());
+    }
+
+    #[test]
+    fn test_aliases_for_no_matches() {
+        let registry = AliasRegistry::new();
+        let matches = registry.aliases_for("nonexistent_command");
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_expand_empty_string() {
+        let registry = AliasRegistry::new();
+        assert!(registry.expand("").is_none());
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn expand_never_panics(input: String) {
+            let registry = AliasRegistry::new();
+            let _ = registry.expand(&input);
+        }
+
+        #[test]
+        fn is_alias_never_panics(input: String) {
+            let registry = AliasRegistry::new();
+            let _ = registry.is_alias(&input);
+        }
+
+        #[test]
+        fn add_then_expand_roundtrip(alias: String, canonical: String) {
+            let mut registry = AliasRegistry::empty();
+            registry.add(&alias, &canonical);
+            prop_assert_eq!(registry.expand(&alias), Some(canonical.as_str()));
+        }
+
+        #[test]
+        fn remove_then_expand_absent(alias: String, canonical: String) {
+            let mut registry = AliasRegistry::empty();
+            registry.add(&alias, &canonical);
+            registry.remove(&alias);
+            prop_assert!(registry.expand(&alias).is_none());
+        }
+    }
 }

--- a/crates/terraphim_agent/src/forgiving/parser.rs
+++ b/crates/terraphim_agent/src/forgiving/parser.rs
@@ -441,4 +441,94 @@ mod tests {
         assert!(result.is_success());
         assert_eq!(result.command(), Some("custom"));
     }
+
+    #[test]
+    fn test_double_slash_prefix() {
+        let parser = ForgivingParser::default();
+        let result = parser.parse("//search test");
+        assert!(result.is_success());
+        assert_eq!(result.command(), Some("search"));
+    }
+
+    #[test]
+    fn test_special_characters_in_args() {
+        let parser = ForgivingParser::default();
+        let result = parser.parse("search @#$% hello-world");
+        assert!(result.is_success());
+        assert_eq!(result.args(), Some("@#$% hello-world"));
+    }
+
+    #[test]
+    fn test_very_long_input() {
+        let parser = ForgivingParser::default();
+        let long_args = "a".repeat(10000);
+        let result = parser.parse(&format!("search {}", long_args));
+        assert!(result.is_success());
+        assert_eq!(result.args().unwrap().len(), 10000);
+    }
+
+    #[test]
+    fn test_empty_command_returns_none_accessors() {
+        let parser = ForgivingParser::default();
+        let result = parser.parse("");
+        assert!(matches!(result, ParseResult::Empty));
+        assert!(result.command().is_none());
+        assert!(result.args().is_none());
+        assert!(result.original().is_none());
+        assert!(result.full_command().is_none());
+        assert!(!result.was_corrected());
+        assert!(!result.was_alias());
+    }
+
+    #[test]
+    fn test_add_commands() {
+        let mut parser = ForgivingParser::new(vec!["search".to_string()]);
+        parser.add_commands(&["graph", "role"]);
+        assert_eq!(parser.known_commands().len(), 3);
+        let result = parser.parse("graph");
+        assert!(result.is_success());
+    }
+
+    #[test]
+    fn test_aliases_accessor() {
+        let parser = ForgivingParser::default();
+        assert!(parser.aliases().expand("q").is_some());
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn parse_never_panics(input: String) {
+            let parser = ForgivingParser::default();
+            let _ = parser.parse(&input);
+        }
+
+        #[test]
+        fn parse_result_accessors_never_panics(input: String) {
+            let parser = ForgivingParser::default();
+            let result = parser.parse(&input);
+            let _ = result.command();
+            let _ = result.original();
+            let _ = result.args();
+            let _ = result.full_command();
+            let _ = result.was_corrected();
+            let _ = result.was_alias();
+            let _ = result.is_success();
+        }
+
+        #[test]
+        fn empty_string_always_empty(input: String) {
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                let parser = ForgivingParser::default();
+                let result = parser.parse(&input);
+                prop_assert!(matches!(result, ParseResult::Empty));
+            }
+        }
+    }
 }

--- a/crates/terraphim_agent/src/forgiving/suggestions.rs
+++ b/crates/terraphim_agent/src/forgiving/suggestions.rs
@@ -153,4 +153,70 @@ mod tests {
         assert!(!suggestions.is_empty());
         assert_eq!(suggestions[0].command, "search");
     }
+
+    #[test]
+    fn test_high_confidence_boundary() {
+        let suggestion = CommandSuggestion::new("search", "searcg");
+        assert!(suggestion.edit_distance <= 2);
+        assert!(suggestion.similarity > 0.8);
+        assert!(suggestion.is_high_confidence());
+    }
+
+    #[test]
+    fn test_reasonable_boundary() {
+        let suggestion = CommandSuggestion::new("search", "srch");
+        assert!(suggestion.is_reasonable());
+    }
+
+    #[test]
+    fn test_empty_command_list() {
+        let suggestions: Vec<&str> = vec![];
+        let result = find_similar_commands("search", &suggestions, 5);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_best_match_empty_commands() {
+        let suggestions: Vec<&str> = vec![];
+        assert!(find_best_match("search", &suggestions).is_none());
+    }
+
+    #[test]
+    fn test_max_suggestions_respected() {
+        let commands = vec!["search", "config", "role", "graph", "help", "quit"];
+        let suggestions = find_similar_commands("searc", &commands, 2);
+        assert!(suggestions.len() <= 2);
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn edit_distance_non_negative(a: String, b: String) {
+            let d = edit_distance(&a, &b);
+            prop_assert!(d == d); // sanity: always returns a valid usize
+        }
+
+        #[test]
+        fn edit_distance_zero_for_identical(s: String) {
+            prop_assert_eq!(edit_distance(&s, &s), 0);
+        }
+
+        #[test]
+        fn similarity_in_range(a: String, b: String) {
+            let s = similarity(&a, &b);
+            prop_assert!(s >= 0.0);
+            prop_assert!(s <= 1.0);
+        }
+
+        #[test]
+        fn find_similar_never_panics(input: String) {
+            let commands = vec!["search", "config", "role"];
+            let _ = find_similar_commands(&input, &commands, 5);
+        }
+    }
 }

--- a/crates/terraphim_agent/src/robot/docs.rs
+++ b/crates/terraphim_agent/src/robot/docs.rs
@@ -690,4 +690,50 @@ mod tests {
         assert!(json.contains("search"));
         assert!(json.contains("query"));
     }
+
+    #[test]
+    fn test_search_aliases_present() {
+        let docs = SelfDocumentation::new();
+        let search_doc = docs.schema("search").unwrap();
+        assert!(search_doc.aliases.contains(&"q".to_string()));
+        assert!(search_doc.aliases.contains(&"query".to_string()));
+        assert!(search_doc.aliases.contains(&"find".to_string()));
+    }
+
+    #[test]
+    fn test_help_command_has_aliases() {
+        let docs = SelfDocumentation::new();
+        let help_doc = docs.schema("help").unwrap();
+        assert!(help_doc.aliases.contains(&"h".to_string()));
+        assert!(help_doc.aliases.contains(&"?".to_string()));
+    }
+
+    #[test]
+    fn test_unknown_command_schema() {
+        let docs = SelfDocumentation::new();
+        assert!(docs.schema("nonexistent_xyz").is_none());
+    }
+
+    #[test]
+    fn test_unknown_command_examples() {
+        let docs = SelfDocumentation::new();
+        assert!(docs.examples("nonexistent_xyz").is_none());
+    }
+
+    #[test]
+    fn test_all_commands_have_names() {
+        let docs = SelfDocumentation::new();
+        for cmd in &docs.commands {
+            assert!(!cmd.name.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_command_doc_roundtrip() {
+        let docs = SelfDocumentation::new();
+        let config_doc = docs.schema("config").unwrap();
+        let json = serde_json::to_string(config_doc).unwrap();
+        let deserialized: CommandDoc = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.name, "config");
+    }
 }

--- a/crates/terraphim_agent/src/robot/output.rs
+++ b/crates/terraphim_agent/src/robot/output.rs
@@ -210,12 +210,22 @@ impl RobotFormatter {
     pub fn truncate_content(&self, content: &str) -> (String, bool) {
         if let Some(max_len) = self.config.max_content_length {
             if content.len() > max_len {
-                // Truncate at word boundary if possible
-                let truncated = if let Some(pos) = content[..max_len].rfind(char::is_whitespace) {
-                    &content[..pos]
+                let safe_boundary = if content.is_char_boundary(max_len) {
+                    max_len
                 } else {
-                    &content[..max_len]
+                    content
+                        .char_indices()
+                        .take_while(|(i, _)| *i < max_len)
+                        .last()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0)
                 };
+                let truncated =
+                    if let Some(pos) = content[..safe_boundary].rfind(char::is_whitespace) {
+                        &content[..pos]
+                    } else {
+                        &content[..safe_boundary]
+                    };
                 return (format!("{}...", truncated), true);
             }
         }
@@ -310,5 +320,153 @@ mod tests {
         let output = formatter.format(&data).unwrap();
         assert!(output.contains("key"));
         assert!(output.contains("value"));
+    }
+
+    #[test]
+    fn test_formatter_jsonl_streaming() {
+        let formatter = RobotFormatter::new(RobotConfig::new().with_format(OutputFormat::Jsonl));
+        let items = vec![serde_json::json!({"id": 1}), serde_json::json!({"id": 2})];
+        let output = formatter.format_stream(items).unwrap();
+        assert!(output.contains('\n'));
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 2);
+    }
+
+    #[test]
+    fn test_formatter_minimal_format() {
+        let formatter = RobotFormatter::new(RobotConfig::new().with_format(OutputFormat::Minimal));
+        let data = serde_json::json!({"key": "value"});
+        let output = formatter.format(&data).unwrap();
+        assert!(!output.contains('\n'));
+    }
+
+    #[test]
+    fn test_formatter_table_format() {
+        let formatter = RobotFormatter::new(RobotConfig::new().with_format(OutputFormat::Table));
+        let data = serde_json::json!({"key": "value"});
+        let output = formatter.format(&data).unwrap();
+        assert!(output.contains("key"));
+    }
+
+    #[test]
+    fn test_would_exceed_budget() {
+        let config = RobotConfig::new().with_max_tokens(5);
+        let formatter = RobotFormatter::new(config);
+        assert!(formatter.would_exceed_budget("this is more than twenty chars"));
+        assert!(!formatter.would_exceed_budget("hi"));
+    }
+
+    #[test]
+    fn test_no_budget_unlimited() {
+        let formatter = RobotFormatter::new(RobotConfig::new());
+        assert!(!formatter.would_exceed_budget(&"x".repeat(10000)));
+    }
+
+    #[test]
+    fn test_output_format_from_str() {
+        use std::str::FromStr;
+        assert!(OutputFormat::from_str("json").is_ok());
+        assert!(OutputFormat::from_str("jsonl").is_ok());
+        assert!(OutputFormat::from_str("unknown_format").is_err());
+    }
+
+    #[test]
+    fn test_output_format_name() {
+        assert_eq!(OutputFormat::Json.name(), "json");
+        assert_eq!(OutputFormat::Jsonl.name(), "jsonl");
+        assert_eq!(OutputFormat::Minimal.name(), "minimal");
+        assert_eq!(OutputFormat::Table.name(), "table");
+    }
+
+    #[test]
+    fn test_field_mode_custom_empty() {
+        let mode = FieldMode::from_str_loose("custom:");
+        assert_eq!(mode, FieldMode::Custom(vec![]));
+    }
+
+    #[test]
+    fn test_field_mode_unknown_defaults_full() {
+        assert_eq!(FieldMode::from_str_loose("unknown"), FieldMode::Full);
+    }
+
+    #[test]
+    fn test_robot_config_default() {
+        let config = RobotConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.format, OutputFormat::Json);
+        assert_eq!(config.max_results, Some(10));
+    }
+
+    #[test]
+    fn test_robot_config_builder() {
+        let config = RobotConfig::new()
+            .with_format(OutputFormat::Jsonl)
+            .with_max_tokens(100)
+            .with_max_results(5)
+            .with_max_content_length(200)
+            .with_fields(FieldMode::Minimal);
+        assert!(config.enabled);
+        assert_eq!(config.format, OutputFormat::Jsonl);
+        assert_eq!(config.max_tokens, Some(100));
+        assert_eq!(config.max_results, Some(5));
+        assert_eq!(config.max_content_length, Some(200));
+        assert_eq!(config.fields, FieldMode::Minimal);
+    }
+
+    #[test]
+    fn test_truncation_word_boundary() {
+        let config = RobotConfig::new().with_max_content_length(10);
+        let formatter = RobotFormatter::new(config);
+        let (truncated, was_truncated) = formatter.truncate_content("hello world test");
+        assert!(was_truncated);
+        assert!(!truncated.contains("world"));
+    }
+
+    #[test]
+    fn test_truncation_no_whitespace() {
+        let config = RobotConfig::new().with_max_content_length(5);
+        let formatter = RobotFormatter::new(config);
+        let (truncated, was_truncated) = formatter.truncate_content("abcdefgh");
+        assert!(was_truncated);
+        assert!(truncated.starts_with("abcde"));
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn format_never_panics(key: String, value: String) {
+            let formatter = RobotFormatter::new(RobotConfig::new());
+            let data = serde_json::json!({ key: value });
+            let _ = formatter.format(&data);
+        }
+
+        #[test]
+        fn truncate_never_panics(content: String) {
+            let config = RobotConfig::new().with_max_content_length(50);
+            let formatter = RobotFormatter::new(config);
+            let (result, _) = formatter.truncate_content(&content);
+            if content.len() > 50 {
+                prop_assert!(result.contains("..."));
+            }
+        }
+
+        #[test]
+        fn from_str_loose_never_panics(input: String) {
+            let _ = OutputFormat::from_str_loose(&input);
+            let _ = FieldMode::from_str_loose(&input);
+        }
+
+        #[test]
+        fn format_stream_empty_is_empty(_input: String) {
+            let formatter = RobotFormatter::new(RobotConfig::new());
+            let items: Vec<serde_json::Value> = vec![];
+            let output = formatter.format_stream(items).unwrap();
+            prop_assert!(output.is_empty());
+        }
     }
 }

--- a/crates/terraphim_agent/src/robot/schema.rs
+++ b/crates/terraphim_agent/src/robot/schema.rs
@@ -402,4 +402,95 @@ mod tests {
         assert!(json.contains("E001"));
         assert!(json.contains("serach"));
     }
+
+    #[test]
+    fn test_meta_with_auto_correction() {
+        let meta = ResponseMeta::new("search").with_auto_correction(AutoCorrection {
+            original: "serach".to_string(),
+            corrected: "search".to_string(),
+            distance: 2,
+        });
+        assert!(meta.auto_corrected.is_some());
+        let ac = meta.auto_corrected.unwrap();
+        assert_eq!(ac.original, "serach");
+        assert_eq!(ac.corrected, "search");
+        assert_eq!(ac.distance, 2);
+    }
+
+    #[test]
+    fn test_meta_with_pagination() {
+        let meta = ResponseMeta::new("search").with_pagination(Pagination::new(100, 10, 0));
+        assert!(meta.pagination.is_some());
+    }
+
+    #[test]
+    fn test_search_result_item_serialization_roundtrip() {
+        let item = SearchResultItem {
+            rank: 1,
+            id: "doc-1".to_string(),
+            title: "Test Document".to_string(),
+            url: Some("https://example.com".to_string()),
+            score: 0.95,
+            preview: Some("A test document".to_string()),
+            source: Some("test".to_string()),
+            date: None,
+            preview_truncated: false,
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        let deserialized: SearchResultItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, "doc-1");
+        assert_eq!(deserialized.title, "Test Document");
+        assert_eq!(deserialized.rank, 1);
+    }
+
+    #[test]
+    fn test_preview_truncated_skip_serializing_false() {
+        let item = SearchResultItem {
+            rank: 1,
+            id: "doc-1".to_string(),
+            title: "Test".to_string(),
+            url: None,
+            score: 0.5,
+            preview: None,
+            source: None,
+            date: None,
+            preview_truncated: false,
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(!json.contains("preview_truncated"));
+    }
+
+    #[test]
+    fn test_preview_truncated_included_when_true() {
+        let item = SearchResultItem {
+            rank: 1,
+            id: "doc-1".to_string(),
+            title: "Test".to_string(),
+            url: None,
+            score: 0.5,
+            preview: None,
+            source: None,
+            date: None,
+            preview_truncated: true,
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("preview_truncated"));
+    }
+
+    #[test]
+    fn test_token_budget_serialization() {
+        let budget = TokenBudget::new(1000);
+        let json = serde_json::to_string(&budget).unwrap();
+        let deserialized: TokenBudget = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.max_tokens, 1000);
+        assert!(!deserialized.truncated);
+        assert_eq!(deserialized.estimated_tokens, 0);
+    }
+
+    #[test]
+    fn test_robot_error_no_results() {
+        let error = RobotError::no_results("missing query");
+        let json = serde_json::to_string(&error).unwrap();
+        assert!(json.contains("missing query"));
+    }
 }

--- a/crates/terraphim_agent/tests/phase1_robot_mode_tests.rs
+++ b/crates/terraphim_agent/tests/phase1_robot_mode_tests.rs
@@ -1,0 +1,148 @@
+use terraphim_agent::forgiving::{AliasRegistry, ForgivingParser};
+use terraphim_agent::robot::{
+    ExitCode, FieldMode, OutputFormat, ResponseMeta, RobotConfig, RobotFormatter, RobotResponse,
+};
+
+#[test]
+fn test_parser_to_robot_formatter_pipeline() {
+    let parser = ForgivingParser::default();
+    let result = parser.parse("serach hello world");
+
+    assert!(result.is_success());
+    assert_eq!(result.command(), Some("search"));
+
+    let config = RobotConfig::new().with_format(OutputFormat::Json);
+    let formatter = RobotFormatter::new(config);
+
+    let payload = serde_json::json!({
+        "command": result.command(),
+        "args": result.args(),
+        "corrected": result.was_corrected(),
+    });
+    let output = formatter.format(&payload).unwrap();
+    assert!(output.contains("search"));
+    assert!(output.contains("hello world"));
+}
+
+#[test]
+fn test_alias_expansion_to_robot_output() {
+    let parser = ForgivingParser::default();
+    let result = parser.parse("q test query");
+
+    assert!(result.is_success());
+    assert!(result.was_alias());
+    assert_eq!(result.command(), Some("search"));
+
+    let formatter = RobotFormatter::new(RobotConfig::new());
+    let meta = ResponseMeta::new("search");
+    let response = RobotResponse::success(
+        serde_json::json!({"query": "test query", "results": []}),
+        meta,
+    );
+    let output = formatter.format(&response).unwrap();
+    assert!(output.contains("success"));
+    assert!(output.contains("test query"));
+}
+
+#[test]
+fn test_exit_codes_for_search_outcomes() {
+    assert_eq!(ExitCode::Success.code(), 0);
+    assert_eq!(ExitCode::ErrorNotFound.code(), 4);
+    assert_eq!(ExitCode::ErrorUsage.code(), 2);
+    assert_eq!(ExitCode::ErrorGeneral.code(), 1);
+}
+
+#[test]
+fn test_format_flag_json() {
+    let config = RobotConfig::new().with_format(OutputFormat::Json);
+    let formatter = RobotFormatter::new(config);
+    let data = serde_json::json!({"status": "ok"});
+    let output = formatter.format(&data).unwrap();
+    assert!(output.contains('\n'));
+}
+
+#[test]
+fn test_format_flag_jsonl() {
+    let config = RobotConfig::new().with_format(OutputFormat::Jsonl);
+    let formatter = RobotFormatter::new(config);
+    let data = serde_json::json!({"status": "ok"});
+    let output = formatter.format(&data).unwrap();
+    assert!(!output.contains('\n'));
+}
+
+#[test]
+fn test_format_flag_minimal() {
+    let config = RobotConfig::new().with_format(OutputFormat::Minimal);
+    let formatter = RobotFormatter::new(config);
+    let data = serde_json::json!({"status": "ok"});
+    let output = formatter.format(&data).unwrap();
+    assert!(!output.contains('\n'));
+}
+
+#[test]
+fn test_field_modes_with_formatter() {
+    let config = RobotConfig::new()
+        .with_fields(FieldMode::Minimal)
+        .with_max_results(5);
+    assert_eq!(config.fields, FieldMode::Minimal);
+    assert_eq!(config.max_results, Some(5));
+}
+
+#[test]
+fn test_error_response_with_exit_code() {
+    let meta = ResponseMeta::new("search");
+    use terraphim_agent::robot::RobotError;
+    let errors = vec![RobotError::no_results("xyz")];
+    let response = RobotResponse::<()>::error(errors, meta);
+
+    assert!(!response.success);
+    assert!(response.data.is_none());
+    assert!(!response.errors.is_empty());
+
+    let exit_code = if response.success {
+        ExitCode::Success
+    } else {
+        ExitCode::ErrorNotFound
+    };
+    assert_eq!(exit_code.code(), 4);
+}
+
+#[test]
+fn test_custom_alias_registry_with_parser() {
+    let mut aliases = AliasRegistry::empty();
+    aliases.add("ls", "sessions list");
+    aliases.add("ss", "sessions search");
+
+    let parser = ForgivingParser::new(vec![
+        "sessions".to_string(),
+        "search".to_string(),
+        "list".to_string(),
+    ])
+    .with_aliases(aliases);
+
+    let result = parser.parse("ls");
+    assert!(result.is_success());
+    assert!(result.was_alias());
+}
+
+#[test]
+fn test_robot_config_is_robot_mode() {
+    let config = RobotConfig::new();
+    assert!(config.is_robot_mode());
+
+    let default_config = RobotConfig::default();
+    assert!(!default_config.is_robot_mode());
+}
+
+#[test]
+fn test_truncation_with_budget() {
+    let config = RobotConfig::new()
+        .with_max_content_length(50)
+        .with_max_tokens(100);
+    let formatter = RobotFormatter::new(config);
+
+    let long_content = "x".repeat(200);
+    let (truncated, was_truncated) = formatter.truncate_content(&long_content);
+    assert!(was_truncated);
+    assert!(truncated.len() <= 53);
+}


### PR DESCRIPTION
## Summary

- Adds comprehensive tests for Phase 1 modules: forgiving parser (aliases, parser, suggestions), robot output (formats, config, formatter), schema (serialisation round-trips), and docs (self-documentation)
- Adds `proptest` dev-dependency for property-based testing (12 proptest cases)
- Bug fix: proptest discovered a UTF-8 panic in `RobotFormatter::shorten_content` when `max_content_length` falls mid-character -- fixed with `is_char_boundary` + char-safe slicing
- New integration test file `tests/phase1_robot_mode_tests.rs` with 11 end-to-end tests

## Test counts
- 228 lib tests (up from 168 -- 60 new)
- 11 integration tests (new file)
- 0 new clippy warnings

## Test plan
- [x] cargo fmt passes
- [x] cargo clippy passes
- [x] 228 lib tests pass
- [x] 11 integration tests pass
- [x] Pre-commit hooks pass

Refs terraphim/terraphim-ai#697 (Gitea)