### PR TITLE
feat(agent): wire RobotFormatter into CLI search and ForgivingParser into REPL

### DIFF
--- a/crates/terraphim_agent/src/main.rs
+++ b/crates/terraphim_agent/src/main.rs
@@ -579,26 +579,6 @@ fn resolve_output_config(robot: bool, format: OutputFormat) -> CommandOutputConf
     CommandOutputConfig { mode, robot }
 }
 
-#[derive(Debug, Serialize)]
-struct SearchDocumentOutput {
-    id: String,
-    title: String,
-    url: String,
-    rank: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    body: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct SearchOutput {
-    query: String,
-    role: String,
-    count: usize,
-    results: Vec<SearchDocumentOutput>,
-}
-
 #[cfg(feature = "repl-sessions")]
 mod session_output {
     use serde::Serialize;
@@ -1592,27 +1572,75 @@ async fn run_offline_command(
             };
 
             if output.is_machine_readable() {
-                let payload = SearchOutput {
-                    query,
-                    role: role_name.to_string(),
-                    count: results.len(),
-                    results: results
-                        .iter()
-                        .map(|doc| SearchDocumentOutput {
+                use crate::robot::schema::{SearchResultItem, SearchResultsData};
+                use crate::robot::{ResponseMeta, RobotConfig, RobotFormatter, RobotResponse};
+                use std::time::Instant;
+
+                let start = Instant::now();
+                let robot_format = match output.mode {
+                    CommandOutputMode::JsonCompact => crate::robot::output::OutputFormat::Minimal,
+                    _ => crate::robot::output::OutputFormat::Json,
+                };
+                let mut robot_config = RobotConfig::new()
+                    .with_format(robot_format)
+                    .with_max_results(limit);
+                if output.robot {
+                    robot_config = robot_config
+                        .with_max_content_length(2000)
+                        .with_max_tokens(8000);
+                }
+
+                let formatter = RobotFormatter::new(robot_config.clone());
+                let max_results = robot_config.max_results.unwrap_or(limit);
+                let truncated_results: Vec<_> = results.into_iter().take(max_results).collect();
+                let total = truncated_results.len();
+
+                let items: Vec<SearchResultItem> = truncated_results
+                    .iter()
+                    .enumerate()
+                    .map(|(i, doc)| {
+                        let preview = doc.description.as_deref().or(if doc.body.is_empty() {
+                            None
+                        } else {
+                            Some(doc.body.as_str())
+                        });
+                        let (preview_text, preview_truncated) = match preview {
+                            Some(text) => {
+                                let (t, was_truncated) = formatter.truncate_content(text.trim());
+                                (Some(t), was_truncated)
+                            }
+                            None => (None, false),
+                        };
+                        SearchResultItem {
+                            rank: i + 1,
                             id: doc.id.clone(),
                             title: doc.title.clone(),
-                            url: doc.url.clone(),
-                            rank: doc.rank,
-                            description: doc.description.clone(),
-                            body: if doc.body.is_empty() {
+                            url: if doc.url.is_empty() {
                                 None
                             } else {
-                                Some(doc.body.clone())
+                                Some(doc.url.clone())
                             },
-                        })
-                        .collect(),
+                            score: doc.rank.unwrap_or_default() as f64,
+                            preview: preview_text,
+                            source: None,
+                            date: None,
+                            preview_truncated,
+                        }
+                    })
+                    .collect();
+
+                let data = SearchResultsData {
+                    results: items,
+                    total_matches: total,
+                    concepts_matched: vec![],
+                    wildcard_fallback: false,
                 };
-                print_json_output(&payload, output.mode)?;
+
+                let meta =
+                    ResponseMeta::new("search").with_elapsed(start.elapsed().as_millis() as u64);
+                let response = RobotResponse::success(data, meta);
+                let output_str = formatter.format(&response)?;
+                println!("{}", output_str);
             } else {
                 for doc in results.iter() {
                     let snippet = doc
@@ -3463,32 +3491,75 @@ async fn run_server_command(
             }
 
             if output.is_machine_readable() {
-                let payload = SearchOutput {
-                    query,
-                    role: q
-                        .role
-                        .as_ref()
-                        .map(|r| r.to_string())
-                        .unwrap_or_else(|| "unknown".to_string()),
-                    count: res.results.len(),
-                    results: res
-                        .results
-                        .iter()
-                        .map(|doc| SearchDocumentOutput {
+                use crate::robot::schema::{SearchResultItem, SearchResultsData};
+                use crate::robot::{ResponseMeta, RobotConfig, RobotFormatter, RobotResponse};
+                use std::time::Instant;
+
+                let start = Instant::now();
+                let robot_format = match output.mode {
+                    CommandOutputMode::JsonCompact => crate::robot::output::OutputFormat::Minimal,
+                    _ => crate::robot::output::OutputFormat::Json,
+                };
+                let mut robot_config = RobotConfig::new()
+                    .with_format(robot_format)
+                    .with_max_results(limit);
+                if output.robot {
+                    robot_config = robot_config
+                        .with_max_content_length(2000)
+                        .with_max_tokens(8000);
+                }
+
+                let formatter = RobotFormatter::new(robot_config.clone());
+                let max_results = robot_config.max_results.unwrap_or(limit);
+                let truncated_results: Vec<_> = res.results.into_iter().take(max_results).collect();
+                let total = truncated_results.len();
+
+                let items: Vec<SearchResultItem> = truncated_results
+                    .iter()
+                    .enumerate()
+                    .map(|(i, doc)| {
+                        let preview = doc.description.as_deref().or(if doc.body.is_empty() {
+                            None
+                        } else {
+                            Some(doc.body.as_str())
+                        });
+                        let (preview_text, preview_truncated) = match preview {
+                            Some(text) => {
+                                let (t, was_truncated) = formatter.truncate_content(text.trim());
+                                (Some(t), was_truncated)
+                            }
+                            None => (None, false),
+                        };
+                        SearchResultItem {
+                            rank: i + 1,
                             id: doc.id.clone(),
                             title: doc.title.clone(),
-                            url: doc.url.clone(),
-                            rank: doc.rank,
-                            description: doc.description.clone(),
-                            body: if doc.body.is_empty() {
+                            url: if doc.url.is_empty() {
                                 None
                             } else {
-                                Some(doc.body.clone())
+                                Some(doc.url.clone())
                             },
-                        })
-                        .collect(),
+                            score: doc.rank.unwrap_or_default() as f64,
+                            preview: preview_text,
+                            source: None,
+                            date: None,
+                            preview_truncated,
+                        }
+                    })
+                    .collect();
+
+                let data = SearchResultsData {
+                    results: items,
+                    total_matches: total,
+                    concepts_matched: vec![],
+                    wildcard_fallback: false,
                 };
-                print_json_output(&payload, output.mode)?;
+
+                let meta =
+                    ResponseMeta::new("search").with_elapsed(start.elapsed().as_millis() as u64);
+                let response = RobotResponse::success(data, meta);
+                let output_str = formatter.format(&response)?;
+                println!("{}", output_str);
             } else {
                 for doc in res.results.iter() {
                     let snippet = doc

--- a/crates/terraphim_agent/src/repl/handler.rs
+++ b/crates/terraphim_agent/src/repl/handler.rs
@@ -10,6 +10,7 @@ use crate::client::ApiClient;
 use crate::service::TuiService;
 
 // Import robot module types
+use crate::forgiving::parser::ForgivingParser;
 use crate::robot::{ExitCode, SelfDocumentation};
 
 #[cfg(feature = "repl-mcp")]
@@ -255,7 +256,107 @@ impl ReplHandler {
     }
 
     async fn execute_command(&mut self, input: &str) -> Result<bool> {
-        let command = ReplCommand::from_str(input)?;
+        let parser = ForgivingParser::new(
+            ReplCommand::available_commands()
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        );
+        let parse_result = parser.parse(input.trim());
+
+        let (effective_input, correction_msg) = match parse_result {
+            crate::forgiving::parser::ParseResult::Exact { .. } => (input.to_string(), None),
+            crate::forgiving::parser::ParseResult::AliasExpanded {
+                original,
+                command,
+                args,
+            } => {
+                let reconstructed = if args.is_empty() {
+                    format!("/{}", command)
+                } else {
+                    format!("/{} {}", command, args)
+                };
+                (
+                    reconstructed,
+                    Some(format!("[alias] {} -> {}", original, command)),
+                )
+            }
+            crate::forgiving::parser::ParseResult::AutoCorrected {
+                original,
+                command,
+                distance,
+                args,
+            } => {
+                let reconstructed = if args.is_empty() {
+                    format!("/{}", command)
+                } else {
+                    format!("/{} {}", command, args)
+                };
+                (
+                    reconstructed,
+                    Some(format!(
+                        "[auto-corrected] {} -> {} (distance={})",
+                        original, command, distance
+                    )),
+                )
+            }
+            crate::forgiving::parser::ParseResult::Suggestions {
+                original,
+                suggestions,
+            } => {
+                #[cfg(feature = "repl")]
+                {
+                    use colored::Colorize;
+                    println!(
+                        "{} Unknown command: {}",
+                        "X".red().bold(),
+                        original.yellow()
+                    );
+                    if !suggestions.is_empty() {
+                        println!(
+                            "  {} Did you mean: {}?",
+                            "hint:".blue(),
+                            suggestions
+                                .iter()
+                                .take(3)
+                                .map(|s| s.command.green().to_string())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        );
+                    }
+                }
+                return Ok(false);
+            }
+            crate::forgiving::parser::ParseResult::Unknown { original } => {
+                #[cfg(feature = "repl")]
+                {
+                    use colored::Colorize;
+                    println!(
+                        "{} Unknown command: {}",
+                        "X".red().bold(),
+                        original.yellow()
+                    );
+                }
+                return Ok(false);
+            }
+            crate::forgiving::parser::ParseResult::Empty => {
+                return Ok(false);
+            }
+        };
+
+        if let Some(msg) = &correction_msg {
+            #[cfg(feature = "repl")]
+            {
+                use colored::Colorize;
+                eprintln!("{}", msg.blue());
+            }
+            #[cfg(not(feature = "repl"))]
+            {
+                let _ = msg;
+            }
+        }
+
+        let command = ReplCommand::from_str(&effective_input)?;
 
         match command {
             ReplCommand::Search {


### PR DESCRIPTION
## Summary
- Wire `RobotFormatter` + `RobotResponse` envelope into CLI search output (both offline and server mode) when `--robot` or `--format json` is used
- Wire `ForgivingParser` into REPL command dispatch with auto-correction messages
- Remove dead `SearchOutput`/`SearchDocumentOutput` structs

## Changes
- `main.rs`: CLI search uses `RobotResponse<SearchResultsData>` with timing metadata, `max_results`, `max_content_length` from `RobotConfig`
- `handler.rs`: REPL `execute_command` runs input through `ForgivingParser` first; prints `[alias]` or `[auto-corrected]` messages; shows suggestions for unknown commands

Refs terraphim/terraphim-ai#781 (Gitea)