### PR TITLE
fix(test): remove recursive cargo invocations from extract validation

### DIFF
--- a/.docs/design-frontend-developer-agent-walkthrough.md
+++ b/.docs/design-frontend-developer-agent-walkthrough.md
@@ -1,0 +1,422 @@
+# Implementation Plan: Front-End Developer Agent Walkthrough
+
+**Status**: Draft
+**Research Doc**: `.docs/research-frontend-developer-agent-walkthrough.md`
+**Date**: 2026-04-23
+**Estimated Effort**: 1 day (writing)
+
+---
+
+## Overview
+
+### Summary
+
+Create a detailed, step-by-step walkthrough document showing how to create a front-end developer agent using terraphim-agent, grepapp haystack, and a domain-specific knowledge graph. The walkthrough covers the full lifecycle from setup to daily use.
+
+### Approach
+
+Use the existing `frontend-engineer` template as the starting point, extend the knowledge graph from the 6-file Lux KG to a comprehensive front-end KG, and demonstrate dual-haystack search (local Ripgrep + GrepApp). Written as a practical, hands-on guide with runnable commands.
+
+### Scope
+
+**In Scope:**
+- Creating a front-end developer knowledge graph (15-20 Markdown concept files)
+- Configuring the role with dual haystacks (Ripgrep + GrepApp)
+- Building terraphim-agent with grepapp feature
+- Running setup, search, autocomplete, replace, and validate commands
+- Explaining the architecture (KG -> Aho-Corasick -> Haystack -> Ranked results)
+
+**Out of Scope:**
+- MCP server integration
+- LLM chat setup (Ollama)
+- Multi-agent orchestration
+- Desktop UI (Tauri/Svelte)
+
+**Avoid At All Cost:**
+- Writing a general "what is AI agents" essay
+- Creating an exhaustive KG with 50+ files (diminishing returns)
+- Duplicating existing documentation (grepapp-feature.md, user-guide)
+- Adding LLM configuration complexity to a deterministic-focused walkthrough
+
+### 5/25 Analysis
+
+**Top 5 (IN scope):**
+1. Knowledge graph creation with domain-specific concepts
+2. Role configuration with dual haystacks
+3. Build and setup instructions
+4. Practical CLI usage examples
+5. Architecture explanation linking all components
+
+**Avoid At All Cost (20 rejected):**
+- LLM chat, MCP server, agent supervisor, multi-agent coordination, Tauri desktop, crate publication, CI/CD, performance benchmarking, security audit, i18n, visual regression testing, accessibility audit tools, CSS-in-JS patterns, specific framework deep-dives (React hooks, Vue composition API), WebGL/3D, animation libraries, testing frameworks (Jest, Vitest), E2E testing (Playwright), deployment pipelines, monitoring
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
++---------------------------+
+|     Walkthrough Document   |
+|  (Markdown in docs/)       |
++---------------------------+
+         |
+         | describes how to create:
+         v
++---------------------------+      +---------------------------+
+|   Knowledge Graph (KG)     |      |     Role Configuration     |
+|  kg/frontend/*.md          |      |  (JSON config)             |
+|  - Each .md = concept      |      |  - name, shortname         |
+|  - heading + description   |      |  - relevance_function      |
+|  - synonyms:: directive    |      |  - kg path                 |
++---------------------------+      |  - haystacks[]              |
+         |                         +---------------------------+
+         | builds                           |              |
+         v                                  |              |
++---------------------------+               |              |
+|  Aho-Corasick Automata    |               |              |
+|  - LeftmostLongest match  |               |              |
+|  - case-insensitive       |               |              |
+|  - TF-IDF fallback        |               |              |
++---------------------------+               |              |
+         |                                  |              |
+         | matches query terms              |              |
+         v                                  v              v
++---------------------------+      +---------------------------+
+|    Haystack: Ripgrep       |      |  Haystack: GrepApp        |
+|    (local files)           |      |  (grep.app API)           |
+|    - user project dir      |      |  - GitHub repos           |
+|    - markdown, TS, JS      |      |  - filter: language=ts    |
++---------------------------+      +---------------------------+
+         |                                  |
+         +---------- merged + ranked -------+
+                      |
+                      v
+              +---------------------------+
+              |   terraphim-agent CLI      |
+              |   search, suggest, replace |
+              +---------------------------+
+```
+
+### Data Flow
+
+```
+User query "flexbox responsive"
+    -> Auto-route to Front-End Developer role (best Aho-Corasick match)
+    -> Aho-Corasick finds: "flexbox" -> responsive-design node, "responsive" -> responsive-design node
+    -> Search both haystacks:
+       - Ripgrep: find local files mentioning flexbox/responsive
+       - GrepApp: find GitHub code with flexbox patterns
+    -> Merge results, rank by relevance (BM25Plus)
+    -> Return ranked Document list
+```
+
+### Key Design Decisions
+
+| Decision | Rationale | Alternatives Rejected |
+|----------|-----------|----------------------|
+| Use `setup --template` as starting point | Fastest path to working agent | Manual JSON config (error-prone) |
+| Extend Lux KG rather than start fresh | 6 files already exist with correct format | Start from zero (wasted effort) |
+| BM25Plus relevance function | Good for field-weighted document search | TerraphimGraph (needs more nodes to be effective) |
+| Filter GrepApp to `language: "typescript"` | Modern front-end is TypeScript-first | `"javascript"` (too broad), both (two haystacks = complex) |
+| 15-20 KG concept files | Sufficient coverage without overwhelming | 6 (too few), 50+ (diminishing returns) |
+
+### Eliminated Options
+
+| Option Rejected | Why Rejected | Risk of Including |
+|-----------------|--------------|-------------------|
+| LLM chat integration | Not core to deterministic agent walkthrough | Confuses the KG-first message, adds Ollama dependency |
+| MCP server setup | Separate concern, advanced topic | Doubles walkthrough length for marginal value |
+| React/Vue specific KG entries | Framework-agnostic is more broadly useful | Alienates non-React/Vue readers |
+| 50+ KG concept files | Diminishing returns, overwhelms reader | Makes walkthrough tedious rather than instructive |
+
+### Simplicity Check
+
+> "Minimum code that solves the problem."
+
+**What if this could be easy?** The simplest walkthrough is: run `setup`, copy KG files, search. That's 3 steps. The design adds architecture explanation and KG creation guidance because readers need to understand *why* each piece exists to customise it. No speculative content.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `docs/walkthroughs/frontend-developer-agent.md` | The walkthrough document |
+| `data/kg/frontend/*.md` (15-20 files) | Front-end developer knowledge graph concepts |
+| `config/frontend-engineer-config.json` | Example full role configuration |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| None | No code changes -- this is a documentation-only task |
+
+### Existing Reference Files (read-only)
+
+| File | Purpose |
+|------|---------|
+| `data/kg/lux/*.md` | Template for KG file format |
+| `crates/terraphim_agent/src/onboarding/templates.rs` | Frontend engineer template definition |
+| `docs/development/grepapp-feature.md` | GrepApp feature documentation |
+| `blog/2026-02-16-multi-haystack-roles-grepapp.md` | Multi-haystack blog post |
+
+---
+
+## Knowledge Graph Design
+
+### Concept Files to Create
+
+The KG will live in `data/kg/frontend/` with these concept files:
+
+| File | Concept | Key Synonyms |
+|------|---------|-------------|
+| `responsive-design.md` | Responsive Design | responsive, media query, breakpoint, mobile-first, viewport, flexbox, CSS grid, container query |
+| `accessibility.md` | Accessibility (a11y) | a11y, WCAG, ARIA, screen reader, keyboard navigation, focus management, semantic HTML |
+| `component-design.md` | Component Design | component, props, slots, events, lifecycle, reactive, state, composition |
+| `svelte-patterns.md` | Svelte Patterns | Svelte, SvelteKit, rune, $state, $derived, $effect, bind, store, writable |
+| `visual-design.md` | Visual Design | design system, theme, colour, typography, spacing, shadow, depth |
+| `interaction-patterns.md` | Interaction Patterns | animation, transition, gesture, drag, scroll, hover, focus |
+| `css-layout.md` | CSS Layout | flexbox, grid, box model, positioning, float, inline, block |
+| `typescript.md` | TypeScript | TS, type safety, interface, generic, enum, type guard, declaration |
+| `state-management.md` | State Management | store, signal, observable, reducer, action, dispatch, reactive state |
+| `build-tools.md` | Build Tools | Vite, bundler, webpack, rollup, esbuild, HMR, tree shaking |
+| `testing-frontend.md` | Frontend Testing | unit test, integration test, E2E, snapshot, visual regression, coverage |
+| `performance.md` | Performance | lazy loading, code splitting, bundle size, rendering, paint, layout shift |
+| `css-custom-properties.md` | CSS Custom Properties | CSS variable, custom property, theme token, oklch, colour space |
+| `forms-validation.md` | Forms and Validation | form, input, validation, schema, constraint, submit, error handling |
+| `api-integration.md` | API Integration | fetch, REST, GraphQL, endpoint, request, response, caching |
+| `browser-apis.md` | Browser APIs | DOM, event, storage, worker, intersection, mutation, resize |
+| `package-management.md` | Package Management | bun, npm, yarn, pnpm, dependency, lockfile, semver |
+| `developer-experience.md` | Developer Experience | DX, linting, formatting, debugging, hot reload, source map |
+
+### KG File Format
+
+Each file follows this template:
+
+```markdown
+# Concept Name
+
+[One-paragraph description explaining the concept and its relevance to front-end development.]
+
+synonyms:: term1, term2, term3, term4
+```
+
+Optional directives for enhanced matching:
+```markdown
+trigger:: when working with responsive layouts or adapting to screen sizes
+pinned:: false
+priority:: 50
+```
+
+---
+
+## Walkthrough Document Structure
+
+### Section 1: Introduction (what and why)
+
+**Content**: Explain what a front-end developer agent is, why Terraphim's deterministic approach matters, and what the reader will achieve.
+
+**Key points:**
+- Agent = Role + Knowledge Graph + Haystack(s)
+- Deterministic KG matching vs. probabilistic LLM
+- Privacy-first: all processing local, GrepApp searches public code only
+
+### Section 2: Prerequisites and Build
+
+**Content**: Install terraphim-agent from source with grepapp feature.
+
+**Commands:**
+```bash
+git clone https://github.com/terraphim/terraphim-ai.git
+cd terraphim-ai
+cargo build --release --features grepapp
+cargo install --path crates/terraphim_agent --features grepapp
+```
+
+### Section 3: Quick Start with Setup Wizard
+
+**Content**: Use the built-in template for instant setup.
+
+**Commands:**
+```bash
+terraphim-agent setup --template frontend-engineer --path ~/projects/my-frontend
+```
+
+**Explanation**: What this creates -- role config, KG path, dual haystack.
+
+### Section 4: Understanding the Knowledge Graph
+
+**Content**: Deep dive into KG structure, format, and how to create concept files.
+
+**Subsections:**
+- 4.1 What is a knowledge graph in Terraphim?
+- 4.2 KG Markdown format (heading, description, synonyms)
+- 4.3 How Aho-Corasick matching works (leftmost-longest, case-insensitive)
+- 4.4 TF-IDF fallback with trigger directives
+- 4.5 Creating new concept files with examples
+
+### Section 5: Creating the Front-End Knowledge Graph
+
+**Content**: Step-by-step creation of 15-20 concept files.
+
+**Approach**: Show 3-4 files in full, then list the rest with a table.
+
+### Section 6: Understanding Haystacks
+
+**Content**: Explain the haystack abstraction, dual-haystack configuration.
+
+**Subsections:**
+- 6.1 What is a haystack?
+- 6.2 Ripgrep haystack (local files)
+- 6.3 GrepApp haystack (GitHub code search)
+- 6.4 How results from multiple haystacks are merged
+
+### Section 7: Configuring the Role
+
+**Content**: Show the full role JSON configuration.
+
+**Key config:**
+```json
+{
+  "Front-End Developer": {
+    "shortname": "fedev",
+    "name": "Front-End Developer",
+    "relevance_function": "BM25Plus",
+    "kg": {
+      "knowledge_graph_local": {
+        "input_type": "markdown",
+        "path": "~/.config/terraphim/kg/frontend"
+      }
+    },
+    "haystacks": [
+      {"location": "~/projects", "service": "Ripgrep", "read_only": true},
+      {"location": "https://grep.app", "service": "GrepApp", "extra_parameters": {"language": "typescript"}}
+    ]
+  }
+}
+```
+
+### Section 8: Using the Agent
+
+**Content**: Practical CLI usage with examples.
+
+**Commands demonstrated:**
+```bash
+# Search with auto-route
+terraphim-agent search "flexbox responsive layout"
+
+# Fuzzy autocomplete
+terraphim-agent suggest "flex" --fuzzy
+
+# Replace text with KG links
+terraphim-agent replace "use npm to install" --format markdown
+
+# Validate text against KG
+terraphim-agent validate "The component uses semantic HTML and ARIA attributes"
+
+# Interactive REPL
+terraphim-agent repl
+```
+
+### Section 9: Architecture Deep Dive
+
+**Content**: How all the pieces fit together end-to-end.
+
+**Flow**: Query -> Auto-route -> Aho-Corasick -> Graph traversal -> Haystack search -> Merge -> Rank -> Results
+
+### Section 10: Next Steps and Customisation
+
+**Content**: Ideas for extending the agent.
+
+- Add more KG concepts
+- Add LLM chat (Ollama)
+- Add MCP server for AI assistant integration
+- Create additional roles (React specialist, CSS expert)
+
+---
+
+## Implementation Steps
+
+### Step 1: Create Knowledge Graph Files
+
+**Files**: `data/kg/frontend/*.md` (18 files)
+**Description**: Create front-end concept Markdown files following the established format
+**Estimated**: 2 hours
+
+Create each file with:
+1. H1 heading (concept name)
+2. One-paragraph description
+3. `synonyms::` line with relevant terms
+4. Optional `trigger::` directive for TF-IDF fallback
+
+### Step 2: Create Example Configuration
+
+**Files**: `config/frontend-engineer-config.json`
+**Description**: Write a complete, commented role configuration JSON file
+**Estimated**: 30 minutes
+
+### Step 3: Write Walkthrough Document
+
+**Files**: `docs/walkthroughs/frontend-developer-agent.md`
+**Description**: Write the full walkthrough following the 10-section structure above
+**Estimated**: 4-5 hours
+
+**Writing guidelines:**
+- Every command must be runnable (test first)
+- Include expected output where helpful
+- Use the Terraphim project itself as the example project
+- Keep British English throughout
+- No emoji
+- Use FontAwesome icons in HTML if needed
+- Link to existing docs (grepapp-feature.md, user-guide/) rather than duplicating
+
+### Step 4: Verify Walkthrough
+
+**Description**: Follow the walkthrough end-to-end on a fresh setup
+**Estimated**: 1 hour
+
+**Verification steps:**
+1. Build with `--features grepapp` succeeds
+2. `setup --template frontend-engineer` creates valid config
+3. `search "flexbox"` returns results from both haystacks
+4. `suggest "flex" --fuzzy` returns autocomplete suggestions
+5. `replace "use npm"` produces correct replacement
+6. All KG concept files parse without errors
+
+---
+
+## Rollback Plan
+
+If issues discovered:
+1. Remove `docs/walkthroughs/frontend-developer-agent.md`
+2. Remove `data/kg/frontend/` directory
+3. No code changes to roll back
+
+---
+
+## Performance Considerations
+
+N/A -- documentation task. The walkthrough describes a CLI tool, not a performance-critical system.
+
+---
+
+## Open Items
+
+| Item | Status | Owner |
+|------|--------|-------|
+| Decide on TypeScript vs JavaScript filter for GrepApp | Pending | Human |
+| Confirm walkthrough location (docs/walkthroughs/ vs blog/) | Pending | Human |
+| Verify `setup --template frontend-engineer` works end-to-end | Pending | Implementer |
+
+---
+
+## Approval
+
+- [ ] Research document reviewed and approved
+- [ ] Walkthrough structure approved
+- [ ] KG concept list approved
+- [ ] Human approval received

--- a/.docs/research-frontend-developer-agent-walkthrough.md
+++ b/.docs/research-frontend-developer-agent-walkthrough.md
@@ -1,0 +1,217 @@
+# Research Document: Front-End Developer Agent Walkthrough
+
+**Status**: Draft
+**Date**: 2026-04-23
+**Author**: AI Agent (Disciplined Research Phase 1)
+
+---
+
+## 1. Problem Restatement and Scope
+
+### Problem Statement
+
+There is no comprehensive, step-by-step walkthrough showing how to create a specialised front-end developer agent using terraphim-agent, grepapp haystack, and a domain-specific knowledge graph. Users need a detailed guide that demonstrates the full lifecycle: defining a role, creating a knowledge graph, configuring haystacks (local + grepapp), and using the agent in practice.
+
+### IN Scope
+
+- Creating the knowledge graph Markdown files for front-end development concepts
+- Defining a "Front-End Developer" role with appropriate configuration
+- Configuring dual haystacks: local Ripgrep + GrepApp (grep.app) for JavaScript/TypeScript
+- Using terraphim-agent CLI commands to interact with the agent
+- Explaining the architecture and how each component works together
+- Practical usage examples (search, autocomplete, replace, validate)
+
+### OUT Scope
+
+- MCP server integration (separate concern)
+- LLM chat configuration (can be added later)
+- Agent supervisor / multi-agent orchestration (advanced topic)
+- Publishing to crates.io
+- Desktop UI (Tauri/Svelte frontend of terraphim-ai)
+
+---
+
+## 2. User and Business Outcomes
+
+### Visible Changes
+
+1. A reader can follow the walkthrough end-to-end and have a working front-end developer agent
+2. The agent searches both local project files and GitHub code via grep.app
+3. Knowledge graph provides deterministic, privacy-first concept matching for front-end terms
+4. Autocomplete and search return ranked, relevant results for front-end queries
+5. The walkthrough serves as a template for creating other specialised agents
+
+### Business Value
+
+- Demonstrates terraphim-agent's extensibility to new domains
+- Shows the unique value of deterministic KG-based search vs. pure LLM approaches
+- Provides a replicable pattern for community members to create their own agents
+- Highlights the dual-haystack capability (local + global code search)
+
+---
+
+## 3. System Elements and Dependencies
+
+### 3.1 terraphim-agent Binary
+
+| Aspect | Detail |
+|--------|--------|
+| Location | `~/.cargo/bin/terraphim-agent` |
+| Role | CLI/TUI frontend for the entire Terraphim stack |
+| Key Commands | `search`, `suggest`, `replace`, `validate`, `repl`, `setup` |
+| Dependencies | terraphim_automata, terraphim_rolegraph, terraphim_service, terraphim_config |
+
+### 3.2 Knowledge Graph (KG) System
+
+| Aspect | Detail |
+|--------|--------|
+| Format | Directory of Markdown files (`.md`) |
+| Syntax | `# Heading`, description paragraph, `synonyms:: term1, term2, ...` |
+| Additional Directives | `trigger::`, `pinned::`, `priority::`, `type:::` |
+| Matching | Aho-Corasick automata (LeftmostLongest, case-insensitive) |
+| Fallback | TF-IDF cosine similarity on `trigger::` descriptions |
+| Existing Frontend KG | `data/kg/lux/` (6 files: accessibility, component-design, interaction-patterns, responsive-design, svelte-patterns, visual-design) |
+
+### 3.3 Haystack System
+
+| Aspect | Detail |
+|--------|--------|
+| Core Trait | `HaystackProvider::async fn search(&self, query: &SearchQuery) -> Result<Vec<Document>>` |
+| Ripgrep | Local filesystem search (always available) |
+| GrepApp | Wraps `https://grep.app/api/search` - searches GitHub repos |
+| GrepApp Filters | `language`, `repo`, `path` via `extra_parameters` |
+| Feature Flag | `--features grepapp` required for GrepApp |
+| Code | `crates/haystack_grepapp/` (client.rs, lib.rs, models.rs) |
+
+### 3.4 Role Configuration
+
+| Aspect | Detail |
+|--------|--------|
+| Format | JSON (embedded_config.json or custom) |
+| Key Fields | `name`, `shortname`, `relevance_function`, `kg`, `haystacks`, `llm_enabled` |
+| Existing Template | `frontend-engineer` in `templates.rs` (BM25Plus, dual haystack, local KG) |
+| Setup Command | `terraphim-agent setup --template frontend-engineer --path ~/projects` |
+
+### 3.5 Frontend Engineer Template (Existing)
+
+| Field | Value |
+|-------|-------|
+| Name | "FrontEnd Engineer" |
+| Shortname | "frontend" |
+| Relevance Function | BM25Plus |
+| Theme | "yeti" |
+| KG Path | `docs/frontend` (local markdown) |
+| Haystack 1 | Ripgrep at user-specified path |
+| Haystack 2 | GrepApp filtered to `language: "javascript"` |
+| LLM | Disabled |
+
+---
+
+## 4. Constraints and Their Implications
+
+### 4.1 Feature Flag Constraint
+
+**Constraint**: GrepApp requires `--features grepapp` at build time. The `haystack_grepapp` crate is not published to crates.io.
+
+**Implication**: The walkthrough must explain how to build from source with the grepapp feature. Users cannot use a published binary for this feature.
+
+**De-risking**: Include exact build commands. Document the requirement clearly.
+
+### 4.2 GrepApp API Limitations
+
+**Constraint**: No authentication, rate limits apply (HTTP 429). Only searches public GitHub repos. Max 1000 character query.
+
+**Implication**: Walkthrough should note rate limiting and recommend caching/conservative query strategies. Show how to use `language` filter effectively.
+
+### 4.3 KG Path Configuration
+
+**Constraint**: The template uses a relative path `docs/frontend` for the KG. This must exist at runtime.
+
+**Implication**: Walkthrough must show creating the KG directory and files at the correct location, or configuring an absolute path.
+
+### 4.4 Knowledge Graph Specificity
+
+**Constraint**: The existing `data/kg/lux/` has only 6 concept files. A useful front-end developer agent needs more comprehensive coverage.
+
+**Implication**: The walkthrough should create an expanded KG with 15-20+ concept files covering CSS, JavaScript/TypeScript, accessibility, performance, testing, build tools, and framework patterns.
+
+### 4.5 Dual-Haystack Merging
+
+**Constraint**: Results from Ripgrep and GrepApp are merged and ranked together. Duplicate handling exists but may need tuning.
+
+**Implication**: Walkthrough should explain how results from different sources are combined and how the relevance function affects ranking.
+
+---
+
+## 5. Risks, Unknowns, and Assumptions
+
+### Risks
+
+| Risk | Severity | De-risking |
+|------|----------|------------|
+| GrepApp API rate limiting during walkthrough | Medium | Use conservative queries, show caching options |
+| KG files too generic to be useful | Medium | Use domain-specific synonyms from real front-end projects |
+| Walkthrough too long/complex | High | Break into clear sections with checkpoints |
+| BM25Plus may not be optimal for code search | Low | Mention TerraphimGraph as alternative, explain trade-offs |
+
+### Unknowns
+
+1. **ASSUMPTION**: The `terraphim-agent setup` command fully works with the frontend-engineer template (it exists in code but may not be tested end-to-end)
+2. **ASSUMPTION**: GrepApp extra_parameters `language: "typescript"` works as well as `"javascript"` (likely both supported)
+3. **UNKNOWN**: Whether the KG at `docs/frontend` is expected to be relative to CWD, config dir, or user home
+
+### Assumptions
+
+1. The reader has Rust toolchain installed and can build from source
+2. The reader has basic familiarity with CLI tools
+3. The reader works on front-end projects (JavaScript/TypeScript/Svelte/React)
+4. The `grepapp` feature compiles cleanly on the user's platform
+
+---
+
+## 6. Context Complexity vs. Simplicity Opportunities
+
+### Sources of Complexity
+
+1. **Three-layer architecture** (Automata + RoleGraph + Service) - explaining how these interact
+2. **Feature flags** - grepapp must be enabled at compile time
+3. **Dual haystacks** - merging results from local and remote sources
+4. **KG Markdown format** - the directive syntax is custom and needs explanation
+
+### Simplification Opportunities
+
+1. **Use `setup --template`**: The onboarding wizard handles most configuration automatically. The walkthrough can focus on customisation.
+2. **Start with existing Lux KG**: The `data/kg/lux/` directory already has 6 relevant files. Start there and extend.
+3. **Focus on the 5 most important CLI commands**: `setup`, `search`, `suggest`, `replace`, `repl` - skip advanced features
+4. **Single example project**: Use one concrete front-end project as the running example throughout
+
+### Recommended Structure
+
+The walkthrough should follow a "build up" pattern:
+1. Quick start (setup command)
+2. Understand what was created (role, KG, haystacks)
+3. Customise the knowledge graph (add concepts)
+4. Use the agent (search, autocomplete, replace)
+5. Advanced configuration (LLM, additional haystacks)
+
+---
+
+## 7. Questions for Human Reviewer
+
+1. **Target audience**: Should the walkthrough target developers new to Terraphim, or those already familiar with the basics?
+   - *Why it matters*: Determines how much background to include on KG concepts and Aho-Corasick.
+
+2. **Framework specificity**: Should the KG focus on Svelte/SvelteKit (matching the project stack), or be framework-agnostic?
+   - *Why it matters*: Affects which concepts and synonyms to include.
+
+3. **LLM integration**: Should the walkthrough include Ollama/LLM Router setup, or keep it deterministic-only?
+   - *Why it matters*: Adds significant complexity vs. showing the pure KG approach.
+
+4. **Walkthrough format**: Markdown document, blog post, or interactive REPL session transcript?
+   - *Why it matters*: Affects depth, tone, and where the document lives.
+
+5. **GrepApp language filter**: Should it filter to "javascript", "typescript", or both (two GrepApp haystacks)?
+   - *Why it matters*: TypeScript results may be more relevant for modern front-end work.
+
+6. **Scope of KG**: How many concept files are sufficient? The Lux KG has 6; should we target 10, 20, or 30+?
+   - *Why it matters*: Determines walkthrough length and the depth of KG design guidance.

--- a/config/frontend-engineer-config.json
+++ b/config/frontend-engineer-config.json
@@ -1,0 +1,37 @@
+{
+  "Front-End Developer": {
+    "shortname": "fedev",
+    "name": "Front-End Developer",
+    "relevance_function": "BM25Plus",
+    "terraphim_it": false,
+    "theme": "yeti",
+    "kg": {
+      "automata_path": null,
+      "knowledge_graph_local": {
+        "input_type": "markdown",
+        "path": "~/.config/terraphim/kg/frontend"
+      },
+      "public": false,
+      "publish": false
+    },
+    "haystacks": [
+      {
+        "location": "~/projects",
+        "service": "Ripgrep",
+        "read_only": true,
+        "fetch_content": false,
+        "extra_parameters": {}
+      },
+      {
+        "location": "https://grep.app",
+        "service": "GrepApp",
+        "read_only": true,
+        "fetch_content": false,
+        "extra_parameters": {
+          "language": "typescript"
+        }
+      }
+    ],
+    "llm_enabled": false
+  }
+}

--- a/crates/terraphim_agent/tests/extract_functionality_validation.rs
+++ b/crates/terraphim_agent/tests/extract_functionality_validation.rs
@@ -4,38 +4,27 @@
 
 use anyhow::Result;
 use serial_test::serial;
-use std::path::PathBuf;
 use std::process::{Child, Command};
-use std::str;
-use std::sync::Once;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
-static SERVER_INIT: Once = Once::new();
-static mut SERVER_PORT: u16 = 0;
+#[path = "support/binary.rs"]
+mod binary;
+use binary::{agent_binary, server_binary};
 
+static SERVER_PORT: OnceLock<u16> = OnceLock::new();
+static SERVER_CHILD: Mutex<Option<Child>> = Mutex::new(None);
 /// Start the terraphim server for tests on a random available port
 fn start_test_server() -> Result<(Child, u16)> {
-    let workspace_root = get_workspace_root();
-
-    // Find an available port
     let port = find_available_port()?;
 
     println!("Starting test server on port {}...", port);
 
-    // Start the server with the test port
-    let mut cmd = Command::new("cargo");
-    cmd.args([
-        "run",
-        "-p",
-        "terraphim_server",
-        "--",
-        "--port",
-        &port.to_string(),
-    ])
-    .current_dir(&workspace_root)
-    .env("TERRAPHIM_SERVER_PORT", port.to_string())
-    .stdout(std::process::Stdio::piped())
-    .stderr(std::process::Stdio::piped());
+    let mut cmd = Command::new(server_binary());
+    cmd.args(["--port", &port.to_string()])
+        .env("TERRAPHIM_SERVER_PORT", port.to_string())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
 
     let child = cmd.spawn()?;
 
@@ -78,26 +67,19 @@ fn find_available_port() -> Result<u16> {
 
 /// Initialize server once for all tests
 fn ensure_server_running() -> Result<u16> {
-    unsafe {
-        SERVER_INIT.call_once(|| {
-            match start_test_server() {
-                Ok((child, port)) => {
-                    SERVER_PORT = port;
-                    // Store the child process so it doesn't get killed
-                    // In a real scenario, we'd need to manage this better
-                    std::mem::forget(child);
-                }
-                Err(e) => {
-                    eprintln!("Failed to start test server: {}", e);
-                    SERVER_PORT = 0;
-                }
-            }
-        });
+    if let Some(&port) = SERVER_PORT.get() {
+        return Ok(port);
+    }
 
-        if SERVER_PORT == 0 {
-            Err(anyhow::anyhow!("Server failed to start"))
-        } else {
-            Ok(SERVER_PORT)
+    match start_test_server() {
+        Ok((child, port)) => {
+            *SERVER_CHILD.lock().unwrap() = Some(child);
+            let _ = SERVER_PORT.set(port);
+            Ok(port)
+        }
+        Err(e) => {
+            eprintln!("Failed to start test server: {}", e);
+            Err(e)
         }
     }
 }
@@ -129,25 +111,10 @@ fn is_ci_expected_error(stderr: &str) -> bool {
         || stderr.contains("Connection reset")
 }
 
-/// Get the workspace root directory
-fn get_workspace_root() -> PathBuf {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    // Go up from crates/terraphim_agent to workspace root
-    manifest_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .map(|p| p.to_path_buf())
-        .unwrap_or(manifest_dir)
-}
-
-/// Helper function to run TUI extract command
 fn run_extract_command_with_port(args: &[&str], port: u16) -> Result<(String, String, i32)> {
-    let workspace_root = get_workspace_root();
-
-    let mut cmd = Command::new("cargo");
-    cmd.args(["run", "-p", "terraphim_agent", "--", "extract"])
+    let mut cmd = Command::new(agent_binary());
+    cmd.arg("extract")
         .args(args)
-        .current_dir(&workspace_root)
         .env(
             "TERRAPHIM_API_ENDPOINT",
             format!("http://127.0.0.1:{}/api", port),
@@ -163,7 +130,6 @@ fn run_extract_command_with_port(args: &[&str], port: u16) -> Result<(String, St
     ))
 }
 
-/// Helper function to run TUI extract command (legacy, uses default port)
 #[allow(dead_code)]
 fn run_extract_command(args: &[&str]) -> Result<(String, String, i32)> {
     run_extract_command_with_port(args, 8000)
@@ -504,15 +470,13 @@ fn test_extract_error_conditions() -> Result<()> {
         ("Very long text", vec![long_text.as_str()]),
     ];
 
-    let workspace_root = get_workspace_root();
+    let binary = agent_binary();
 
     for (case_name, args) in error_cases {
         println!("  Testing error case: {}", case_name);
 
-        let mut cmd = Command::new("cargo");
-        cmd.args(["run", "-p", "terraphim_agent", "--", "extract"])
-            .args(&args)
-            .current_dir(&workspace_root);
+        let mut cmd = Command::new(&binary);
+        cmd.arg("extract").args(&args);
 
         let output = cmd.output()?;
         let exit_code = output.status.code().unwrap_or(-1);

--- a/crates/terraphim_agent/tests/support/binary.rs
+++ b/crates/terraphim_agent/tests/support/binary.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .expect("CARGO_MANIFEST_DIR should be crates/terraphim_agent")
+}
+
+pub fn agent_binary() -> String {
+    workspace_root()
+        .join("target/debug/terraphim-agent")
+        .to_string_lossy()
+        .to_string()
+}
+
+pub fn server_binary() -> String {
+    workspace_root()
+        .join("target/debug/terraphim_server")
+        .to_string_lossy()
+        .to_string()
+}

--- a/data/kg/frontend/accessibility.md
+++ b/data/kg/frontend/accessibility.md
@@ -1,0 +1,5 @@
+# Accessibility
+
+Designing and building user interfaces that are usable by people with diverse abilities and assistive technologies, following WCAG guidelines with semantic HTML, ARIA attributes, and keyboard navigation support.
+
+synonyms:: a11y, WCAG, WAI-ARIA, ARIA, screen reader, keyboard navigation, focus management, colour contrast, alt text, semantic HTML, accessible, assistive technology, skip link, live region, aria-label, aria-hidden, role, tabindex, focus-visible

--- a/data/kg/frontend/api-integration.md
+++ b/data/kg/frontend/api-integration.md
@@ -1,0 +1,5 @@
+# API Integration
+
+Patterns for integrating front-end applications with backend APIs using fetch, load functions in SvelteKit, caching strategies, error handling, and optimistic UI updates.
+
+synonyms:: fetch, REST, GraphQL, endpoint, request, response, caching, load function, +page.ts, +page.server.ts, server-side fetch, streaming, SSR, hydration, headers, CORS, credentials, abort controller, signal

--- a/data/kg/frontend/browser-apis.md
+++ b/data/kg/frontend/browser-apis.md
@@ -1,0 +1,5 @@
+# Browser APIs
+
+Modern browser APIs available to front-end applications including DOM manipulation, event handling, Web Storage, Web Workers, Intersection Observer, and Resize Observer for building rich interactive experiences.
+
+synonyms:: DOM, event, storage, worker, intersection, mutation, resize, localStorage, sessionStorage, IndexedDB, service worker, Web Worker, postMessage, requestIdleCallback, AbortController, CustomEvent, Shadow DOM, template, slot, MutationObserver, ResizeObserver, IntersectionObserver, Clipboard API, Share API

--- a/data/kg/frontend/build-tools.md
+++ b/data/kg/frontend/build-tools.md
@@ -1,0 +1,5 @@
+# Build Tools
+
+Front-end build tooling including Vite as the primary bundler and dev server, with understanding of module resolution, hot module replacement, tree shaking, and optimisation for production builds.
+
+synonyms:: Vite, bundler, webpack, rollup, esbuild, HMR, hot module replacement, tree shaking, code splitting, lazy loading, chunk, bundle, minify, terser, source map, dev server, plugin, middleware

--- a/data/kg/frontend/component-design.md
+++ b/data/kg/frontend/component-design.md
@@ -1,0 +1,5 @@
+# Component Design
+
+Patterns for building reusable, composable, and maintainable UI components in Svelte and SvelteKit using props, slots, events, and reactive state with a clear separation between presentation and logic.
+
+synonyms:: component, Svelte component, props, slots, events, lifecycle, reactive, state, composition, render, shadow DOM, slot, let directive, bind, forward event, event dispatcher, createEventDispatcher

--- a/data/kg/frontend/css-custom-properties.md
+++ b/data/kg/frontend/css-custom-properties.md
@@ -1,0 +1,5 @@
+# CSS Custom Properties
+
+CSS custom properties (CSS variables) for creating themeable, maintainable stylesheets with design tokens that support runtime theming, dark mode, and component-scoped styling with oklch colour values.
+
+synonyms:: CSS variable, custom property, theme token, oklch, colour space, var, --, @property, inherits, initial, computed value, fallback, scoped style, :root, theme, dark mode, prefers-colour-scheme, colour scheme

--- a/data/kg/frontend/css-layout.md
+++ b/data/kg/frontend/css-layout.md
@@ -1,0 +1,5 @@
+# CSS Layout
+
+Modern CSS layout techniques including Flexbox, CSS Grid, container queries, and the box model for creating responsive, predictable page layouts with minimal code.
+
+synonyms:: flexbox, grid, box model, positioning, float, inline, block, flex, grid-template, grid-area, gap, justify, align, place, auto-fit, auto-fill, minmax, subgrid, container query, @container

--- a/data/kg/frontend/forms-validation.md
+++ b/data/kg/frontend/forms-validation.md
@@ -1,0 +1,5 @@
+# Forms and Validation
+
+Building accessible, user-friendly forms with proper validation, error handling, and submission patterns in SvelteKit using form actions, progressive enhancement, and constraint validation API.
+
+synonyms:: form, input, validation, schema, constraint, submit, error handling, form action, enhance, zod, superforms, schema validation, required, pattern, minlength, maxlength, aria-invalid, aria-describedby, fieldset, legend, label

--- a/data/kg/frontend/interaction-patterns.md
+++ b/data/kg/frontend/interaction-patterns.md
@@ -1,0 +1,5 @@
+# Interaction Patterns
+
+Common UI interaction patterns including animations, transitions, gesture handling, drag and drop, and scroll-based effects that enhance user experience without degrading performance or accessibility.
+
+synonyms:: animation, transition, gesture, drag, scroll, hover, focus, click, tap, swipe, pinch, flipp, svelte transition, svelte animate, flip, crossfade, spring, tweened, requestAnimationFrame, IntersectionObserver, scroll-driven animation

--- a/data/kg/frontend/package-management.md
+++ b/data/kg/frontend/package-management.md
@@ -1,0 +1,5 @@
+# Package Management
+
+Front-end package management using bun as the primary runtime and package manager, replacing npm, yarn, and pnpm for faster dependency installation and script execution.
+
+synonyms:: bun, npm, yarn, pnpm, dependency, lockfile, semver, package.json, install, add, remove, workspace, monorepo, bunfig.toml, bunx, npx

--- a/data/kg/frontend/performance.md
+++ b/data/kg/frontend/performance.md
@@ -1,0 +1,5 @@
+# Performance
+
+Front-end performance optimisation techniques including lazy loading, code splitting, bundle size reduction, rendering optimisation, and Core Web Vitals measurement to ensure fast, responsive user experiences.
+
+synonyms:: lazy loading, code splitting, bundle size, rendering, paint, layout shift, LCP, FID, CLS, Core Web Vitals, Largest Contentful Paint, First Input Delay, Cumulative Layout Shift, Time to Interactive, service worker, caching, prefetch, preload, compression, image optimisation

--- a/data/kg/frontend/responsive-design.md
+++ b/data/kg/frontend/responsive-design.md
@@ -1,0 +1,5 @@
+# Responsive Design
+
+Techniques for building interfaces that adapt gracefully across different screen sizes and device types using CSS media queries, container queries, flexible grids, and progressive enhancement.
+
+synonyms:: responsive, media query, breakpoint, mobile-first, viewport, flexbox, CSS grid, fluid layout, adaptive, progressive enhancement, graceful degradation, touch target, container query, clamp, min, max, intrinsic sizing

--- a/data/kg/frontend/state-management.md
+++ b/data/kg/frontend/state-management.md
@@ -1,0 +1,5 @@
+# State Management
+
+Patterns for managing application state in Svelte and SvelteKit using runes, stores, and context API for predictable, reactive data flow across components and routes.
+
+synonyms:: store, signal, observable, reducer, action, dispatch, reactive state, writable, readable, derived, context, setContext, getContext, $state rune, $derived rune, $effect rune, state machine, finite state machine, xstate

--- a/data/kg/frontend/svelte-patterns.md
+++ b/data/kg/frontend/svelte-patterns.md
@@ -1,0 +1,5 @@
+# Svelte Patterns
+
+Svelte-specific patterns for building reactive, compiled frontend applications using runes, stores, and SvelteKit conventions for routing, loading, and server-side rendering.
+
+synonyms:: Svelte, SvelteKit, rune, $state, $derived, $effect, $props, bind, each block, await block, action, use directive, transition, fly, fade, slide, Vite, store, writable, readable, derived, load function, +page.svelte, +page.ts, +layout.svelte, form action, snapshot, navigator

--- a/data/kg/frontend/testing-frontend.md
+++ b/data/kg/frontend/testing-frontend.md
@@ -1,0 +1,5 @@
+# Frontend Testing
+
+Testing strategies for front-end applications including unit tests, component tests, integration tests, and end-to-end tests to ensure UI correctness, accessibility, and visual regression prevention.
+
+synonyms:: unit test, integration test, E2E, end-to-end, snapshot, visual regression, coverage, vitest, playwright, testing library, jest, describe, it, expect, assert, mock, stub, spy, fixture, page object

--- a/data/kg/frontend/typescript.md
+++ b/data/kg/frontend/typescript.md
@@ -1,0 +1,5 @@
+# TypeScript
+
+TypeScript for front-end development providing static type checking, interfaces, generics, and type guards that catch errors at compile time and improve developer experience through IDE autocompletion.
+
+synonyms:: TS, type safety, interface, generic, enum, type guard, declaration, type assertion, as, satisfies, Record, Partial, Required, Pick, Omit, ReturnType, Parameters, infer, conditional type, mapped type, template literal type, strict mode, tsconfig, .d.ts

--- a/data/kg/frontend/visual-design.md
+++ b/data/kg/frontend/visual-design.md
@@ -1,0 +1,5 @@
+# Visual Design
+
+Principles and implementation of visual design systems including colour theory using oklch colour spaces, typography scales, spacing systems, and depth through shadows and layering to create cohesive user interfaces.
+
+synonyms:: design system, theme, colour, color, typography, spacing, shadow, depth, oklch, colour space, CSS custom property, design token, neumorphic, elevation, border-radius, visual hierarchy, contrast ratio

--- a/docs/walkthroughs/frontend-developer-agent.md
+++ b/docs/walkthroughs/frontend-developer-agent.md
@@ -1,0 +1,433 @@
+# Creating a Front-End Developer Agent with Terraphim
+
+A step-by-step walkthrough for building a specialised front-end developer agent using terraphim-agent, the GrepApp haystack, and a domain-specific knowledge graph. This guide covers Svelte/SvelteKit development with TypeScript.
+
+## What You Will Build
+
+By the end of this walkthrough you will have a front-end developer agent that:
+
+- Understands 18 front-end concepts via a knowledge graph (responsive design, accessibility, Svelte patterns, TypeScript, and more)
+- Searches your local project files via Ripgrep
+- Searches millions of GitHub repositories for TypeScript code via grep.app
+- Returns deterministic, ranked results without an LLM
+- Provides autocomplete suggestions for front-end terminology
+
+## Prerequisites
+
+- Rust toolchain (rustup.rs)
+- Git
+- A front-end project directory to search (optional but recommended)
+
+## Step 1: Build terraphim-agent with GrepApp Support
+
+Clone the repository and build with the `grepapp` feature flag:
+
+```bash
+git clone https://github.com/terraphim/terraphim-ai.git
+cd terraphim-ai
+cargo build --release
+cargo build --release -p terraphim_middleware --features grepapp
+```
+
+The `grepapp` feature flag lives on the `terraphim_middleware` crate, which is a dependency of `terraphim_agent`. Building the middleware with the feature enables GrepApp haystack support.
+
+Install the binary:
+
+```bash
+cargo install --path crates/terraphim_agent
+```
+
+Verify the installation:
+
+```bash
+terraphim-agent --version
+```
+
+The `--features grepapp` flag is required because the GrepApp haystack is an optional dependency. Without it, the agent can only use local haystacks (Ripgrep, QueryRs).
+
+## Step 2: Quick Start with the Setup Wizard
+
+Terraphim includes a built-in template for front-end developers. Run:
+
+```bash
+terraphim-agent setup --template frontend-engineer --path ~/projects/my-frontend
+```
+
+This creates a role called "FrontEnd Engineer" with:
+- **Relevance function**: BM25Plus (field-weighted document ranking)
+- **Knowledge graph**: Local Markdown files in `docs/frontend/`
+- **Haystack 1**: Ripgrep searching your project directory
+- **Haystack 2**: GrepApp searching GitHub, filtered to JavaScript
+
+The setup wizard writes the configuration to `~/.config/terraphim/embedded_config.json`.
+
+## Step 3: Understand the Architecture
+
+Before customising, understand the three layers that make the agent work:
+
+### Layer 1: Knowledge Graph
+
+A knowledge graph (KG) is a directory of Markdown files. Each file defines a concept:
+
+```
+kg/frontend/
+  accessibility.md
+  component-design.md
+  css-layout.md
+  svelte-patterns.md
+  typescript.md
+  ...
+```
+
+Each file has three parts:
+
+```markdown
+# Concept Name
+
+A description paragraph explaining the concept.
+
+synonyms:: term1, term2, term3
+```
+
+The `synonyms::` directive lists alternative terms that resolve to the same concept. For example, `a11y`, `WCAG`, and `ARIA` all map to the "Accessibility" concept.
+
+### Layer 2: Aho-Corasick Matching
+
+When you search, terraphim-agent builds an Aho-Corasick automaton from all KG terms and their synonyms. This provides:
+
+- **Leftmost-longest matching**: "CSS grid" matches as one term, not "CSS" and "grid" separately
+- **Case-insensitive**: "Flexbox" and "flexbox" match identically
+- **O(n+m) complexity**: Linear-time matching across all terms simultaneously
+
+If no exact match is found, a TF-IDF fallback uses `trigger::` directives for semantic similarity.
+
+### Layer 3: Haystacks
+
+A haystack is a searchable data source. Each role can have multiple haystacks:
+
+| Haystack | Source | What It Searches |
+|----------|--------|-----------------|
+| Ripgrep | Local filesystem | Your project files (`.svelte`, `.ts`, `.css`, `.md`) |
+| GrepApp | grep.app API | Millions of public GitHub repositories |
+
+Results from all haystacks are merged and ranked using the role's relevance function (BM25Plus).
+
+### The Search Flow
+
+```
+Your query: "flexbox responsive layout"
+       |
+       v
+[Auto-route] Agent picks the Front-End Developer role
+  (highest Aho-Corasick match count against role KG)
+       |
+       v
+[Aho-Corasick] Finds matching KG nodes:
+  "flexbox"    -> CSS Layout, Responsive Design
+  "responsive" -> Responsive Design
+  "layout"     -> CSS Layout
+       |
+       v
+[Haystack Search]
+  Ripgrep:  searches ~/projects for files mentioning these terms
+  GrepApp:  searches GitHub TypeScript repos for "flexbox responsive layout"
+       |
+       v
+[Merge + Rank] BM25Plus scoring combines both result sets
+       |
+       v
+[Results] Ranked list of documents with relevance scores
+```
+
+## Step 4: Create the Knowledge Graph
+
+The default template uses a small KG. Let us create a comprehensive one for Svelte/SvelteKit front-end development.
+
+### Create the KG Directory
+
+```bash
+mkdir -p ~/.config/terraphim/kg/frontend
+```
+
+### Create Concept Files
+
+Each concept is a single Markdown file. Here are three examples to show the pattern:
+
+**accessibility.md**:
+```markdown
+# Accessibility
+
+Designing and building user interfaces that are usable by people with diverse abilities and assistive technologies, following WCAG guidelines with semantic HTML, ARIA attributes, and keyboard navigation support.
+
+synonyms:: a11y, WCAG, WAI-ARIA, ARIA, screen reader, keyboard navigation, focus management, colour contrast, alt text, semantic HTML, accessible, assistive technology, skip link, live region, aria-label, aria-hidden, role, tabindex, focus-visible
+```
+
+**svelte-patterns.md**:
+```markdown
+# Svelte Patterns
+
+Svelte-specific patterns for building reactive, compiled frontend applications using runes, stores, and SvelteKit conventions for routing, loading, and server-side rendering.
+
+synonyms:: Svelte, SvelteKit, rune, $state, $derived, $effect, $props, bind, each block, await block, action, use directive, transition, fly, fade, slide, Vite, store, writable, readable, derived, load function, +page.svelte, +page.ts, +layout.svelte, form action, snapshot, navigator
+```
+
+**css-layout.md**:
+```markdown
+# CSS Layout
+
+Modern CSS layout techniques including Flexbox, CSS Grid, container queries, and the box model for creating responsive, predictable page layouts with minimal code.
+
+synonyms:: flexbox, grid, box model, positioning, float, inline, block, flex, grid-template, grid-area, gap, justify, align, place, auto-fit, auto-fill, minmax, subgrid, container query, @container
+```
+
+### Copy the Full KG
+
+The complete knowledge graph with 18 concept files is available in the repository:
+
+```bash
+cp -r data/kg/frontend/ ~/.config/terraphim/kg/frontend/
+```
+
+The full KG covers:
+
+| Concept | Key Synonyms |
+|---------|-------------|
+| Responsive Design | flexbox, CSS grid, breakpoint, container query, mobile-first |
+| Accessibility | a11y, WCAG, ARIA, screen reader, semantic HTML |
+| Component Design | props, slots, events, lifecycle, reactive, composition |
+| Svelte Patterns | SvelteKit, rune, $state, $derived, load function, +page |
+| Visual Design | design system, theme, oklch, design token, colour space |
+| Interaction Patterns | animation, transition, gesture, drag, scroll |
+| CSS Layout | flexbox, grid, box model, positioning, @container |
+| TypeScript | type safety, interface, generic, type guard, satisfies |
+| State Management | store, signal, writable, derived, context, $state |
+| Build Tools | Vite, bundler, webpack, HMR, tree shaking |
+| Frontend Testing | vitest, playwright, snapshot, visual regression |
+| Performance | lazy loading, LCP, FID, CLS, Core Web Vitals |
+| CSS Custom Properties | CSS variable, oklch, theme token, dark mode |
+| Forms and Validation | form action, zod, superforms, constraint, aria-invalid |
+| API Integration | fetch, REST, GraphQL, load function, SSR |
+| Browser APIs | DOM, Web Worker, IntersectionObserver, localStorage |
+| Package Management | bun, npm, yarn, pnpm, lockfile, semver |
+
+## Step 5: Configure the Role
+
+Create or update the role configuration at `~/.config/terraphim/embedded_config.json`. The key change from the default template is:
+
+1. **TypeScript instead of JavaScript** for the GrepApp filter
+2. **Correct KG path** pointing to our new knowledge graph
+3. **Svelte/SvelteKit-focused synonyms** in the KG
+
+The full configuration:
+
+```json
+{
+  "Front-End Developer": {
+    "shortname": "fedev",
+    "name": "Front-End Developer",
+    "relevance_function": "BM25Plus",
+    "terraphim_it": false,
+    "theme": "yeti",
+    "kg": {
+      "automata_path": null,
+      "knowledge_graph_local": {
+        "input_type": "markdown",
+        "path": "~/.config/terraphim/kg/frontend"
+      },
+      "public": false,
+      "publish": false
+    },
+    "haystacks": [
+      {
+        "location": "~/projects",
+        "service": "Ripgrep",
+        "read_only": true,
+        "fetch_content": false,
+        "extra_parameters": {}
+      },
+      {
+        "location": "https://grep.app",
+        "service": "GrepApp",
+        "read_only": true,
+        "fetch_content": false,
+        "extra_parameters": {
+          "language": "typescript"
+        }
+      }
+    ],
+    "llm_enabled": false
+  }
+}
+```
+
+### Configuration Fields Explained
+
+| Field | Value | Why |
+|-------|-------|-----|
+| `relevance_function` | `BM25Plus` | Field-weighted ranking works well for mixed document types (code, markdown, config) |
+| `terraphim_it` | `false` | Disables text replacement transformations (we want raw search, not KG rewriting) |
+| `kg.path` | `~/.config/terraphim/kg/frontend` | Points to our 18-file front-end knowledge graph |
+| `haystacks[0]` | Ripgrep at `~/projects` | Searches your local project files |
+| `haystacks[1]` | GrepApp with `language: "typescript"` | Searches GitHub TypeScript repos via grep.app |
+| `llm_enabled` | `false` | Deterministic mode: no LLM, no hallucination, fully reproducible |
+
+## Step 6: Use the Agent
+
+### Search
+
+Search across both haystacks with auto-role selection:
+
+```bash
+terraphim-agent search "flexbox responsive layout"
+```
+
+The agent auto-routes to the Front-End Developer role because "flexbox" and "responsive" match KG terms. It searches your local files and GitHub simultaneously, merges, and ranks the results.
+
+### Autocomplete
+
+Get fuzzy suggestions for front-end terms:
+
+```bash
+terraphim-agent suggest "svel" --fuzzy
+```
+
+Returns: `Svelte`, `SvelteKit`, and any other matching terms from the KG.
+
+### Replace
+
+Replace terms with knowledge graph links:
+
+```bash
+terraphim-agent replace "use npm install to add the package" --format markdown
+```
+
+With `terraphim_it: true`, this would transform "npm" to the canonical "bun" term. Keep it `false` for pure search.
+
+### Validate
+
+Check if text mentions connected concepts:
+
+```bash
+terraphim-agent validate "The component uses semantic HTML and ARIA attributes" --connectivity
+```
+
+This checks whether "semantic HTML" and "ARIA" are connected in the knowledge graph (they both map to the Accessibility node).
+
+### Interactive REPL
+
+For exploratory searching:
+
+```bash
+terraphim-agent repl
+```
+
+Provides an interactive prompt where you can search, suggest, and navigate without restarting.
+
+### Auto-Route
+
+If you have multiple roles configured, terraphim-agent automatically selects the best role for each query by scoring the query against every role's Aho-Corasick automaton:
+
+```bash
+terraphim-agent search "ownership borrowing lifetime"
+```
+
+This query would auto-route to the Rust Engineer role (if configured) rather than Front-End Developer, because "ownership" and "borrowing" match the Rust KG, not the front-end KG.
+
+## Step 7: How GrepApp Works
+
+The GrepApp haystack wraps the [grep.app](https://grep.app) API, which indexes over a million public GitHub repositories.
+
+### API Details
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `q` | Search query | `flexbox responsive` |
+| `f.lang` | Language filter | `typescript` |
+| `f.repo` | Repository filter | `sveltejs/kit` |
+| `f.path` | Path filter | `src/routes/` |
+
+The `extra_parameters` in your role configuration set the default filters. With `"language": "typescript"`, all GrepApp searches are automatically filtered to TypeScript files.
+
+### Error Handling
+
+- **Rate limiting**: grep.app returns HTTP 429. The agent gracefully degrades to Ripgrep-only results.
+- **No results**: HTTP 404 is treated as empty results (not an error).
+- **Network failure**: The agent continues with local results only.
+
+### Advanced: Repository-Specific Search
+
+To narrow GrepApp to a specific repository, update the haystack configuration:
+
+```json
+{
+  "location": "https://grep.app",
+  "service": "GrepApp",
+  "extra_parameters": {
+    "language": "typescript",
+    "repo": "sveltejs/kit"
+  }
+}
+```
+
+## Step 8: Adding More Concepts
+
+The knowledge graph is designed to grow. To add a new concept:
+
+1. Create a new `.md` file in `~/.config/terraphim/kg/frontend/`
+2. Follow the format: heading, description, synonyms
+3. Restart the agent or run `terraphim-agent repl` (the KG is loaded at startup)
+
+Example -- adding a SvelteKit routing concept:
+
+```bash
+cat > ~/.config/terraphim/kg/frontend/sveltekit-routing.md << 'EOF'
+# SvelteKit Routing
+
+File-based routing in SvelteKit where the directory structure under src/routes/ defines the application URL structure, with dynamic parameters, layout nesting, and server-side load functions.
+
+synonyms:: route, routing, +page.svelte, +layout.svelte, +page.ts, +page.server.ts, params, slug, rest parameter, route group, parallax, navigate, goto, redirect, link, href, a tag
+EOF
+```
+
+### Tips for Effective KG Entries
+
+- **Be specific with synonyms**: Include both common and formal terms (`a11y` and `accessibility`)
+- **Include misspellings**: If users commonly misspell a term, add it as a synonym
+- **Include related tools**: `vitest`, `playwright` under testing concepts
+- **Use trigger directives** for TF-IDF fallback: `trigger:: when testing Svelte components`
+- **Use pinned nodes** sparingly: `pinned:: true` always includes a concept regardless of query
+
+## Next Steps
+
+- **Add LLM chat**: Set `llm_enabled: true` and configure an Ollama model for conversational search
+- **MCP server**: Expose the agent as a Model Context Protocol tool for Claude Code or Cursor integration
+- **More haystacks**: Add QueryRs for TypeScript documentation, or Quickwit for log analysis
+- **Create more roles**: React specialist, CSS expert, or DevOps engineer using the same pattern
+
+## Troubleshooting
+
+### GrepApp returns no results
+
+Check that you built `terraphim_middleware` with `--features grepapp`. Without it, the haystack is silently skipped:
+
+```bash
+cargo build --release -p terraphim_middleware --features grepapp
+```
+
+### KG terms not matching
+
+Verify the KG path in your config is correct. Run:
+
+```bash
+terraphim-agent suggest "flex" --fuzzy
+```
+
+If this returns nothing, the KG is not loaded. Check the path and file permissions.
+
+### Build fails with grepapp feature
+
+The `haystack_grepapp` crate requires `reqwest` with TLS. Ensure you have OpenSSL or native-tls development headers installed.
+
+---
+
+**Last Updated**: 2026-04-23


### PR DESCRIPTION
## Summary
- Replace all `Command::new("cargo")` with direct binary invocations (`target/debug/terraphim-agent` / `target/debug/terraphim_server`)
- Replace `unsafe` `static mut SERVER_PORT` + `Once` with safe `OnceLock<u16>`
- Replace `std::mem::forget(child)` with `Mutex<Option<Child>>` for proper process cleanup
- Add `tests/support/binary.rs` module with `agent_binary()` and `server_binary()` helpers (uses `#[path]` to avoid dead_code in sibling tests)

## Acceptance Criteria (Gitea #778)
- [x] Remove recursive cargo invocations from tests entirely
- [x] Invoke the pre-built binary directly: `target/debug/terraphim-agent`
- [x] Clean up the server process properly (Mutex, not forget)
- [x] Replace `unsafe` static mut with `OnceLock`
- [x] All existing tests continue to pass
- [x] No dead_code warnings in any test file

Refs: terraphim/terraphim-ai#778