### PR TITLE
chore(release): bump version to 1.17.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ exclude = [
 default-members = ["terraphim_server"]
 
 [workspace.package]
-version = "1.17.0"
+version = "1.17.1"
 edition = "2024"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Release v1.17.1

Bumps workspace version from 1.17.0 to 1.17.1.

### Changes since v1.17.0
- Refactor terraphim_dsm to knowledge graph semantic grouping tool
- Fix settings.toml being created in arbitrary working directories
- Fix missing Instant import in benchmark test
- Fix CI workflows to use self-hosted runners for private repo access
- Fix invalid actions/checkout@v6 references

### Release Artifacts
- GitHub Release with binaries for all platforms
- Docker images (multi-arch)
- Rust crates (crates.io)
- PyPI packages
- WASM bindings