### PR TITLE
fix(orchestrator): warn on world-readable sensitive config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test ranking knowledge graph fixture** added for agent testing
 - **LLM cost tracking** foundation with genai fork integration (Refs #1075)
 - **Spec validation** report for 2026-04-29 documenting 3 fixed, 5 remaining gaps
+- **Documentation gap report v2** generated for 2026-05-07 extending scan to include `pub fn` -- 395 total gaps (agent: 189, orchestrator: 61, types: 48, service: 39, automata: 23, persistence: 12, config: 11, middleware: 8, rolegraph: 4); service and persistence API entry points identified as critical
+- **Documentation gap report** generated for 2026-05-07 identifying 307 missing docs across 9 crates (agent: 139, types: 76, orchestrator: 54, automata: 23, config: 15) -- 45% reduction from 2026-04-29 baseline of 564
 - **Documentation gap report** generated for 2026-05-05 identifying 1,058 missing docs across 12 crates (orchestrator: 445, server: 138, service: 114, agent: 99, types: 98)
 - **GITEA_URL injection** from project config into agent spawn context for orchestrator
 - **Streaming output log drain** for reliable agent output capture (Refs #1219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test ranking knowledge graph fixture** added for agent testing
 - **LLM cost tracking** foundation with genai fork integration (Refs #1075)
 - **Spec validation** report for 2026-04-29 documenting 3 fixed, 5 remaining gaps
+- **Spec validation** report for 2026-05-07 -- FAIL: 2 persistent gaps (single-agent-listener operational gap, meta-coordinator spec coverage gap); 0 new gaps; provider_probe.rs hardening assessed as in-scope for #1233
 - **Documentation gap report v2** generated for 2026-05-07 extending scan to include `pub fn` -- 395 total gaps (agent: 189, orchestrator: 61, types: 48, service: 39, automata: 23, persistence: 12, config: 11, middleware: 8, rolegraph: 4); service and persistence API entry points identified as critical
 - **Documentation gap report** generated for 2026-05-07 identifying 307 missing docs across 9 crates (agent: 139, types: 76, orchestrator: 54, automata: 23, config: 15) -- 45% reduction from 2026-04-29 baseline of 564
 - **Documentation gap report** generated for 2026-05-05 identifying 1,058 missing docs across 12 crates (orchestrator: 445, server: 138, service: 114, agent: 99, types: 98)

--- a/crates/terraphim_orchestrator/orchestrator.example.toml
+++ b/crates/terraphim_orchestrator/orchestrator.example.toml
@@ -3,6 +3,14 @@
 # Copy to orchestrator.toml and adjust paths for your environment.
 # Full 13-agent fleet with persona-specific knowledge graphs,
 # terraphim-agent pre-checks, and disciplined engineering skill chains.
+#
+# SECURITY: After copying, restrict permissions on this file and on the
+# agent tokens file. Both contain secrets (webhook HMAC secret and API tokens).
+#
+#   chmod 600 orchestrator.toml
+#   chmod 600 /opt/ai-dark-factory/agent_tokens.json
+#
+# The orchestrator logs an error at startup if either file is world-readable.
 
 working_dir = "/opt/ai-dark-factory/workspace"
 persona_data_dir = "/opt/ai-dark-factory/personas"

--- a/crates/terraphim_orchestrator/src/config.rs
+++ b/crates/terraphim_orchestrator/src/config.rs
@@ -1065,6 +1065,47 @@ pub(crate) fn validate_model_provider(
     })
 }
 
+/// Emit a tracing error if `path` is world-readable (Unix mode & 0o004 != 0).
+///
+/// Sensitive configuration files (orchestrator config, agent tokens) must not
+/// be world-readable. Any other system user could read API tokens or webhook
+/// secrets. The correct permissions are 0600 (owner read/write only).
+///
+/// This is advisory: the orchestrator continues loading even if the check fails,
+/// so operators can still recover from misconfigured deployments by fixing
+/// permissions while the service is running.
+pub fn warn_if_world_readable(path: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        match std::fs::metadata(path) {
+            Ok(meta) => {
+                let mode = meta.permissions().mode();
+                if mode & 0o004 != 0 {
+                    tracing::error!(
+                        path = %path.display(),
+                        mode = format!("{:04o}", mode & 0o777),
+                        "SECURITY: sensitive file is world-readable. \
+                         Fix immediately: chmod 600 {}",
+                        path.display()
+                    );
+                } else if mode & 0o040 != 0 {
+                    tracing::warn!(
+                        path = %path.display(),
+                        mode = format!("{:04o}", mode & 0o777),
+                        "SECURITY: sensitive file is group-readable. \
+                         Consider: chmod 600 {}",
+                        path.display()
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::debug!(path = %path.display(), error = %e, "could not stat file for permission check");
+            }
+        }
+    }
+}
+
 impl OrchestratorConfig {
     /// Find a project definition by id.
     pub fn project_by_id(&self, id: &str) -> Option<&Project> {
@@ -1126,6 +1167,7 @@ impl OrchestratorConfig {
         path: impl AsRef<std::path::Path>,
     ) -> Result<Self, crate::error::OrchestratorError> {
         let path = path.as_ref();
+        warn_if_world_readable(path);
         let content = std::fs::read_to_string(path)?;
         let mut config = Self::from_toml(&content)?;
 
@@ -2736,5 +2778,44 @@ task = "build"
             config.agents[0].event_only,
             "event_only must survive TOML round-trip when set to true"
         );
+    }
+
+    #[cfg(unix)]
+    mod permission_tests {
+        use std::os::unix::fs::PermissionsExt;
+
+        /// Creates a temp file with the given octal mode and returns its path.
+        fn temp_file_with_mode(content: &str, mode: u32) -> tempfile::TempDir {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test_config.toml");
+            std::fs::write(&path, content).unwrap();
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(mode);
+            std::fs::set_permissions(&path, perms).unwrap();
+            dir
+        }
+
+        #[test]
+        fn warn_if_world_readable_does_not_panic_on_secure_file() {
+            let dir = temp_file_with_mode("content", 0o600);
+            let path = dir.path().join("test_config.toml");
+            // Should complete without panic; warnings are advisory only.
+            super::super::warn_if_world_readable(&path);
+        }
+
+        #[test]
+        fn warn_if_world_readable_does_not_panic_on_world_readable_file() {
+            let dir = temp_file_with_mode("content", 0o644);
+            let path = dir.path().join("test_config.toml");
+            // Logs an error but must not panic or return an error.
+            super::super::warn_if_world_readable(&path);
+        }
+
+        #[test]
+        fn warn_if_world_readable_does_not_panic_on_missing_file() {
+            let path = std::path::Path::new("/nonexistent/path/config.toml");
+            // Should silently log debug and return without panic.
+            super::super::warn_if_world_readable(path);
+        }
     }
 }

--- a/crates/terraphim_orchestrator/src/output_poster.rs
+++ b/crates/terraphim_orchestrator/src/output_poster.rs
@@ -401,64 +401,69 @@ fn build_project_trackers(config: &GiteaOutputConfig) -> ProjectTrackers {
 
     let (agent_trackers, agent_tokens): (HashMap<String, GiteaTracker>, HashMap<String, String>) =
         match &config.agent_tokens_path {
-            Some(path) => match std::fs::read_to_string(path) {
-                Ok(contents) => match serde_json::from_str::<HashMap<String, String>>(&contents) {
-                    Ok(tokens) => {
-                        tracing::info!(
-                            count = tokens.len(),
-                            path = %path.display(),
-                            owner = %config.owner,
-                            repo = %config.repo,
-                            "loaded per-agent Gitea tokens"
-                        );
-                        let mut trackers = HashMap::with_capacity(tokens.len());
-                        let mut raw = HashMap::with_capacity(tokens.len());
-                        for (agent_name, token) in tokens {
-                            let agent_config = GiteaConfig {
-                                base_url: config.base_url.clone(),
-                                token: token.clone(),
-                                owner: config.owner.clone(),
-                                repo: config.repo.clone(),
-                                active_states: vec!["open".to_string()],
-                                terminal_states: vec!["closed".to_string()],
-                                use_robot_api: false,
-                                robot_path: PathBuf::from(ROBOT_PATH),
-                                claim_strategy: ClaimStrategy::PreferRobot,
-                            };
-                            match GiteaTracker::new(agent_config) {
-                                Ok(tracker) => {
-                                    trackers.insert(agent_name.clone(), tracker);
-                                    raw.insert(agent_name, token);
+            Some(path) => {
+                crate::config::warn_if_world_readable(path);
+                match std::fs::read_to_string(path) {
+                    Ok(contents) => {
+                        match serde_json::from_str::<HashMap<String, String>>(&contents) {
+                            Ok(tokens) => {
+                                tracing::info!(
+                                    count = tokens.len(),
+                                    path = %path.display(),
+                                    owner = %config.owner,
+                                    repo = %config.repo,
+                                    "loaded per-agent Gitea tokens"
+                                );
+                                let mut trackers = HashMap::with_capacity(tokens.len());
+                                let mut raw = HashMap::with_capacity(tokens.len());
+                                for (agent_name, token) in tokens {
+                                    let agent_config = GiteaConfig {
+                                        base_url: config.base_url.clone(),
+                                        token: token.clone(),
+                                        owner: config.owner.clone(),
+                                        repo: config.repo.clone(),
+                                        active_states: vec!["open".to_string()],
+                                        terminal_states: vec!["closed".to_string()],
+                                        use_robot_api: false,
+                                        robot_path: PathBuf::from(ROBOT_PATH),
+                                        claim_strategy: ClaimStrategy::PreferRobot,
+                                    };
+                                    match GiteaTracker::new(agent_config) {
+                                        Ok(tracker) => {
+                                            trackers.insert(agent_name.clone(), tracker);
+                                            raw.insert(agent_name, token);
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                agent = %agent_name,
+                                                error = %e,
+                                                "failed to create agent tracker, will use project default"
+                                            );
+                                        }
+                                    }
                                 }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        agent = %agent_name,
-                                        error = %e,
-                                        "failed to create agent tracker, will use project default"
-                                    );
-                                }
+                                (trackers, raw)
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    path = %path.display(),
+                                    error = %e,
+                                    "failed to parse agent tokens JSON, all agents will use project default token"
+                                );
+                                (HashMap::new(), HashMap::new())
                             }
                         }
-                        (trackers, raw)
                     }
                     Err(e) => {
                         tracing::warn!(
                             path = %path.display(),
                             error = %e,
-                            "failed to parse agent tokens JSON, all agents will use project default token"
+                            "failed to read agent tokens file, all agents will use project default token"
                         );
                         (HashMap::new(), HashMap::new())
                     }
-                },
-                Err(e) => {
-                    tracing::warn!(
-                        path = %path.display(),
-                        error = %e,
-                        "failed to read agent tokens file, all agents will use project default token"
-                    );
-                    (HashMap::new(), HashMap::new())
                 }
-            },
+            }
             None => (HashMap::new(), HashMap::new()),
         };
 

--- a/reports/doc-gap-report-20260507-v2.md
+++ b/reports/doc-gap-report-20260507-v2.md
@@ -1,0 +1,129 @@
+# Documentation Gap Report -- 2026-05-07 (Run 2)
+
+**Generated:** 2026-05-07 05:43 CEST
+**Agent:** Ferrox (documentation-generator)
+**Method:** Scan public items (`pub fn`, `pub async fn`, `pub struct`, `pub enum`, `pub trait`, `pub type`) lacking `///` doc comments
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Crates scanned | 9 |
+| Total missing documentation items | **395** |
+| Prior count (morning run, struct/enum only) | 307 |
+| Methodology difference | +88 (fn-level items now included) |
+| Rust files changed since morning run | 0 |
+
+No Rust code changed between the two scans; count difference is purely methodology (this run includes `pub fn`/`pub async fn`).
+
+---
+
+## Per-Crate Breakdown
+
+| Crate | Missing Items | Top File |
+|-------|---------------|----------|
+| terraphim_agent | 189 | client.rs (59 gaps) |
+| terraphim_types | 48 | score/mod.rs (14 gaps) |
+| terraphim_orchestrator | 61 | control_plane/routing.rs (11 gaps) |
+| terraphim_automata | 23 | builder.rs (14 gaps) |
+| terraphim_config | 11 | lib.rs (11 gaps) |
+| terraphim_service | 39 | error.rs (13 gaps) |
+| terraphim_persistence | 12 | conversation.rs (6 gaps) |
+| terraphim_middleware | 8 | command/ripgrep.rs (3 gaps) |
+| terraphim_rolegraph | 4 | lib.rs (4 gaps) |
+
+---
+
+## Critical Gaps (Public API Entry Points)
+
+### terraphim_service -- 39 gaps
+
+Crate-level public API is undocumented:
+
+- `lib.rs:68` -- `ServiceError` (root error type)
+- `lib.rs:122` -- `Result<T>` type alias
+- `lib.rs:124` -- `TerraphimService` (main service struct)
+- `llm.rs:21` -- `SummarizeOptions`
+- `llm.rs:27` -- `ChatOptions`
+- `llm.rs:33` -- `LlmClient` trait (no trait-level doc)
+- `error.rs:116-133` -- error constructor methods have no doc
+
+### terraphim_persistence -- 12 gaps
+
+- `lib.rs:41` -- `DeviceStorage` struct
+- `lib.rs:47` -- `DeviceStorage::instance()`
+- `conversation.rs:42-56` -- conversation mutation methods
+- `error.rs:4` -- `Error` enum
+- `settings.rs:164,349` -- `parse_profile`, `parse_profiles`
+
+### terraphim_orchestrator -- 61 gaps (new: control_plane)
+
+New `control_plane/` sub-module (routing, telemetry, policy) added recently:
+
+- `control_plane/routing.rs:17` -- `RouteSource` enum (11 total gaps in file)
+- `control_plane/routing.rs:38` -- `BudgetPressure`
+- `control_plane/telemetry.rs:70-95` -- telemetry helper methods
+- `flow/config.rs` -- 4 flow configuration types undocumented
+
+### terraphim_agent -- 189 gaps
+
+`client.rs` is the worst single file (59 gaps). `ApiClient` struct and all its methods are undocumented.
+
+---
+
+## API Reference Snippets
+
+Recommended rustdoc stubs for the highest-priority items:
+
+```rust
+/// The primary Terraphim service, providing search, indexing, and AI summarisation.
+///
+/// Constructed via [`TerraphimService::new`] with a validated configuration.
+/// All search operations are async and cancellable.
+pub struct TerraphimService { /* ... */ }
+
+/// Persistent device storage, providing access to documents, roles, and settings.
+///
+/// Implemented as a singleton per device profile. Use [`DeviceStorage::instance`]
+/// to obtain the shared handle.
+pub struct DeviceStorage { /* ... */ }
+
+/// Trait for language-model backend implementations.
+///
+/// Implement this to wire in a new LLM provider. The two required methods are
+/// [`LlmClient::summarize`] and [`LlmClient::chat`].
+pub trait LlmClient { /* ... */ }
+```
+
+---
+
+## Recommendations
+
+### Priority 1 -- Immediate
+
+1. `terraphim_service` lib.rs: Add three-line crate doc (`//!`) and doc comments on `TerraphimService`, `Result`, `ServiceError`.
+2. `terraphim_persistence` lib.rs: Document `DeviceStorage` and `instance()`.
+3. `terraphim_orchestrator` control_plane: Batch-document the routing and telemetry types (recently added, no docs yet).
+
+### Priority 2 -- High
+
+4. `terraphim_agent` client.rs: Document `ApiClient` and its 10 public methods.
+5. `terraphim_types` score/mod.rs: Document `Scorer` trait and `sort_documents`.
+
+### Priority 3 -- Ongoing
+
+6. Introduce CI lint: `cargo doc --no-deps 2>&1 | grep "missing documentation"` as a soft warning gate.
+
+---
+
+## Comparison to Prior Reports
+
+| Date | Scope | Items |
+|------|-------|-------|
+| 2026-04-29 | struct/enum/trait | 564 |
+| 2026-05-07 morning | struct/enum/trait | 307 (-45%) |
+| 2026-05-07 afternoon | + fn/async fn | 395 |
+
+Theme-ID: doc-gap

--- a/reports/doc-gap-report-20260507-v3.md
+++ b/reports/doc-gap-report-20260507-v3.md
@@ -1,0 +1,104 @@
+# Documentation Gap Report -- 2026-05-07 (Afternoon Run)
+
+**Generated:** 2026-05-07 06:45 CEST
+**Agent:** Ferrox (documentation-generator)
+**Method:** Scan public items (`pub fn`, `pub async fn`, `pub struct`, `pub enum`, `pub trait`, `pub type`) lacking `///` doc comments
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Crates scanned | 9 |
+| Rust files changed since v2 (morning) | 0 |
+| Total missing documentation items | **395** (unchanged from v2) |
+| New gaps introduced today | 0 |
+
+No Rust source changes since the v2 scan at 05:43 CEST. All counts carry forward unchanged.
+
+---
+
+## Per-Crate Breakdown (unchanged from v2)
+
+| Crate | Missing Items | Top File |
+|-------|---------------|----------|
+| terraphim_agent | 189 | client.rs (59 gaps) |
+| terraphim_orchestrator | 61 | control_plane/routing.rs (11 gaps) |
+| terraphim_types | 48 | score/mod.rs (14 gaps) |
+| terraphim_service | 39 | error.rs (13 gaps) |
+| terraphim_automata | 23 | builder.rs (14 gaps) |
+| terraphim_persistence | 12 | conversation.rs (6 gaps) |
+| terraphim_config | 11 | lib.rs (11 gaps) |
+| terraphim_middleware | 8 | command/ripgrep.rs (3 gaps) |
+| terraphim_rolegraph | 4 | lib.rs (4 gaps) |
+
+---
+
+## Spec Validation Cross-Reference
+
+The spec validation report (`reports/spec-validation-20260507.md`) confirms:
+- **FAIL** status: 2 persistent gaps remain unresolved
+- No new spec violations introduced today
+- `meta_coordinator.rs` (741 lines, added in build-runner commit) has no corresponding spec document -- flagged as a documentation gap risk
+
+---
+
+## API Reference Snippets (carried from v2)
+
+```rust
+/// The primary Terraphim service, providing search, indexing, and AI summarisation.
+///
+/// Constructed via [`TerraphimService::new`] with a validated configuration.
+/// All search operations are async and cancellable.
+pub struct TerraphimService { /* ... */ }
+
+/// Persistent device storage, providing access to documents, roles, and settings.
+///
+/// Implemented as a singleton per device profile. Use [`DeviceStorage::instance`]
+/// to obtain the shared handle.
+pub struct DeviceStorage { /* ... */ }
+
+/// Trait for language-model backend implementations.
+///
+/// Implement this to wire in a new LLM provider. The two required methods are
+/// [`LlmClient::summarize`] and [`LlmClient::chat`].
+pub trait LlmClient { /* ... */ }
+
+/// Routes agent tasks to the appropriate executor based on budget and availability.
+///
+/// Integrates with [`BudgetPressure`] for back-pressure-aware dispatching.
+pub enum RouteSource { /* ... */ }
+```
+
+---
+
+## Recommendations
+
+### Priority 1 -- Immediate
+
+1. `terraphim_orchestrator` meta_coordinator.rs: New 741-line file with zero doc comments. Requires crate-level doc (`//!`) and docs on at least the public structs and entry-point methods.
+2. `terraphim_service` lib.rs: Document `TerraphimService`, `Result`, `ServiceError` (3 lines each).
+3. `terraphim_persistence` lib.rs: Document `DeviceStorage::instance()`.
+
+### Priority 2 -- High
+
+4. `terraphim_agent` client.rs: Document `ApiClient` and its 10 public methods.
+5. `terraphim_types` score/mod.rs: Document `Scorer` trait and `sort_documents`.
+
+### Priority 3 -- Ongoing
+
+6. CI lint gate: `cargo doc --no-deps 2>&1 | grep "missing documentation"` as a soft-warning step.
+
+---
+
+## Comparison to Prior Reports
+
+| Date | Run | Scope | Items |
+|------|-----|-------|-------|
+| 2026-04-29 | morning | struct/enum/trait | 564 |
+| 2026-05-07 | v1 morning | struct/enum/trait | 307 (-45%) |
+| 2026-05-07 | v2 morning | + fn/async fn | 395 |
+| 2026-05-07 | v3 afternoon | + fn/async fn | 395 (unchanged) |
+
+Theme-ID: doc-gap

--- a/reports/spec-validation-20260507-v2.md
+++ b/reports/spec-validation-20260507-v2.md
@@ -1,0 +1,156 @@
+# Spec Validation Report: 2026-05-07 (v2)
+
+**Validator:** Carthos (Domain Architect)
+**Date:** 2026-05-07 08:33 CEST
+**Prior run:** 2026-05-07 06:33 CEST (no changes detected since)
+**Verdict:** FAIL — 2 persistent gaps, 0 new gaps
+
+---
+
+## Executive Summary
+
+Six specification documents reviewed in `plans/`. No new specs or commits affecting spec compliance since the 06:33 run. Two gaps persist unchanged: `meta_coordinator` still absent from `lib.rs` (blocker, PR #1291 unmerged) and `guard.rs` still absent (medium, #1274 open). All other bounded contexts remain fully implemented.
+
+---
+
+## Specification-by-Specification Validation
+
+### 1. `design-gitea82-correction-event.md` — ✅ FULLY IMPLEMENTED
+
+Verified:
+- `CorrectionType` enum: `crates/terraphim_agent/src/learnings/capture.rs:44`
+- `CorrectionEvent` struct: `capture.rs:502`
+- `capture_correction()` function: exported via `mod.rs:41`
+- `LearningEntry` enum (Learning + Correction + Procedure): `capture.rs:1225`
+- `list_all_entries`, `query_all_entries`: exported via `mod.rs:42-43`
+- `LearnSub::Correction` CLI variant: `main.rs:3138`
+- Secret redaction in capture path: `mod.rs` confirms `redact_secrets` called
+
+All 8 unit tests and 1 CLI integration test specified in the plan are expected covered. Status: stable.
+
+### 2. `design-gitea84-trigger-based-retrieval.md` — ✅ MOSTLY IMPLEMENTED / ⚠️ MINOR GAP
+
+Verified implemented:
+- `trigger` and `pinned` fields on `MarkdownDirectives`: `crates/terraphim_types/src/lib.rs:502-504`
+- `trigger::` and `pinned::` parsing: `crates/terraphim_automata/src/markdown_directives.rs:215-251`
+- `TriggerIndex` struct: `crates/terraphim_rolegraph/src/lib.rs:51`
+- `trigger_index` and `pinned_node_ids` fields on `RoleGraph`: `lib.rs:320-322`
+- `trigger_descriptions` and `pinned_node_ids` on `SerializableRoleGraph`: `lib.rs:271-273`
+- `find_matching_node_ids_with_fallback()`: `lib.rs:451`
+- `load_trigger_index()`: `lib.rs:478`
+- `query_graph_with_trigger_fallback()`: `lib.rs:718`
+- `--include-pinned` flag on search CLI: `main.rs:718`
+- Integration tests: `two_pass_fallback_to_trigger` (`lib.rs:2196`), `pinned_always_included` (`lib.rs:2215`), `serializable_roundtrip_preserves_triggers` (`lib.rs:2233`)
+
+**Minor gap**: The spec's §7 CLI design includes a `KgSub` enum with `kg list --pinned`. This sub-command is absent from `main.rs` (no `KgSub` enum found). The `--include-pinned` flag on the search path covers the primary acceptance criteria (AC6 in spec). The `kg list --pinned` listing command is not in the formal acceptance criteria list. Assessed as **follow-up**, not a blocker.
+
+### 3. `d3-session-auto-capture-plan.md` — ✅ FULLY IMPLEMENTED
+
+Verified:
+- `from_session_commands()`: `crates/terraphim_agent/src/learnings/procedure.rs:412`
+- `extract_bash_commands_from_session()`: `procedure.rs:471`
+- `ProcedureSub::FromSession` variant gated `#[cfg(feature = "repl-sessions")]`: `main.rs:3413`
+- Implementation wires to `ProcedureStore::save_with_dedup()`: `main.rs:3446`
+- `procedure` module no longer behind `#[cfg(test)]`: `mod.rs:31` shows `pub(crate) mod procedure;`
+- Test coverage: 6 unit tests including `test_from_session_commands_basic`, `_filters_trivial`, `_auto_title` confirmed in `procedure.rs`
+
+Status: stable.
+
+### 4. `design-single-agent-listener.md` — ✅ OPERATIONAL (infrastructure concern)
+
+Verified:
+- `~/.config/terraphim/listener-worker.json`: EXISTS (created 2026-04-16)
+- `~/.config/terraphim/scripts/start-listener.sh`: EXISTS (created 2026-04-16)
+- Spec explicitly states "No code changes to the Rust codebase are required"
+- All code-level invariants (claim logic, self-filtering, retry) covered by existing tests in `listener.rs`
+
+Whether the tmux session is currently running is an operational concern outside spec scope. Status: stable.
+
+### 5. `learning-correction-system-plan.md` — ❌ GAP PERSISTS (Phase H)
+
+**Gap G-2026-05-06-1: `guard.rs` module absent**
+
+`crates/terraphim_agent/src/learnings/guard.rs` does not exist. Issue #1274 remains open.
+
+Required by spec Phase H:
+- `ExecutionTier` enum (Allow / Sandbox / Deny)
+- `GuardDecision` type
+- `evaluate_command()` function
+- Integration with Firecracker sandbox tier
+
+**Severity:** Medium — no automated command safety evaluation before procedure replay.
+
+The rest of the plan (Phases A–G) is confirmed implemented per prior runs.
+
+### 6. `research-single-agent-listener.md` — ✅ RESEARCH COMPLETE
+
+Phase 1 artefact only; no implementation deliverables. Status: stable.
+
+---
+
+## Persistent Non-Spec Gap: `meta_coordinator.rs` Orphaned
+
+**Gap G-2026-05-07-1: `meta_coordinator` not declared in `lib.rs`**
+
+`crates/terraphim_orchestrator/src/meta_coordinator.rs` (25 KB, added 2026-05-06) remains absent from the `pub mod` list in `lib.rs` (lines 31–65, 34 declarations confirmed; `meta_coordinator` absent between `mention_chain` and `metrics_persistence`).
+
+Issue #1275 open. PR #1291 exists — **not yet merged**.
+
+Consequence: all 741 lines of `meta_coordinator.rs` are dead code. Five `#[tokio::test]` functions inside are unreachable. The `dispatch_cycle` integration invariant is unverified.
+
+**Severity:** Blocker — entire module is unreachable until declaration is added.
+
+Note: this gap has no corresponding `plans/` spec document. It is tracked via Gitea issue #1275 and PR #1291.
+
+---
+
+## Traceability Matrix
+
+| Req ID | Requirement | Design Ref | Impl Ref | Tests | Evidence | Status |
+|-------:|-------------|------------|----------|-------|----------|--------|
+| REQ-82-001 | `CorrectionEvent` struct with typed corrections | `design-gitea82-correction-event.md §1.2` | `capture.rs:502` | `test_correction_event_roundtrip` | `capture.rs:502` | ✅ |
+| REQ-82-002 | `capture_correction()` with secret redaction | `§1.4` | `capture.rs`, `mod.rs:41` | `test_capture_correction`, `test_correction_secret_redaction` | `mod.rs:41` | ✅ |
+| REQ-82-003 | `LearnSub::Correction` CLI | `§3.1` | `main.rs:3138` | CLI integration test | `main.rs:3138` | ✅ |
+| REQ-82-004 | Unified `list_all_entries` / `query_all_entries` | `§1.5` | `mod.rs:42-43` | `test_list_all_entries_mixed` | `mod.rs:42` | ✅ |
+| REQ-84-001 | `trigger::` / `pinned::` directive parsing | `design-gitea84 §2` | `markdown_directives.rs:215` | `parses_trigger_directive`, `parses_pinned_directive` | `markdown_directives.rs:348` | ✅ |
+| REQ-84-002 | `TriggerIndex` TF-IDF fallback | `§3` | `rolegraph/lib.rs:51` | `tfidf_exact_match_scores_high`, `two_pass_fallback_to_trigger` | `lib.rs:2196` | ✅ |
+| REQ-84-003 | `--include-pinned` search CLI flag | `§7` | `main.rs:718` | Acceptance criteria AC6 | `main.rs:718` | ✅ |
+| REQ-84-004 | `kg list --pinned` CLI command | `§7` | ABSENT | ABSENT | `KgSub` enum not in `main.rs` | ⚠️ |
+| REQ-D3-001 | `learn procedure from-session <id>` CLI | `d3-session §design` | `main.rs:3413` | `test_from_session_commands_basic` | `main.rs:3413` | ✅ |
+| REQ-D3-002 | Trivial command filter | `d3-session §design` | `procedure.rs:412` | `test_from_session_commands_filters_trivial` | `procedure.rs:868` | ✅ |
+| REQ-D3-003 | Feature-gated `repl-sessions` | `d3-session §dependencies` | `main.rs:3413` | N/A | `#[cfg(feature = "repl-sessions")]` | ✅ |
+| PH-H-001 | `ExecutionTier` enum | `learning-correction-plan §Phase H` | `guard.rs` — ABSENT | ABSENT | File does not exist | ❌ |
+| PH-H-002 | `evaluate_command()` | Same | Same | ABSENT | Same | ❌ |
+| META-001 | `meta_coordinator` in public API | Gitea #1275 | `lib.rs` — ABSENT | 5 tests unreachable | `grep meta_coordinator lib.rs` → 0 hits | ❌ |
+
+---
+
+## Gap Summary
+
+| Gap ID | Description | Severity | Issue | Status |
+|--------|-------------|----------|-------|--------|
+| G-2026-05-07-1 | `meta_coordinator` not in `lib.rs` — all code dead | Blocker | #1275, PR #1291 (unmerged) | ❌ OPEN |
+| G-2026-05-06-1 | `guard.rs` absent — Phase H Graduated Guard missing | Medium | #1274 | ❌ OPEN |
+| G-2026-05-07-2 | `kg list --pinned` CLI sub-command absent | Minor follow-up | (no issue) | ⚠️ FOLLOW-UP |
+
+---
+
+## Recommendations (smallest first)
+
+1. **Merge PR #1291** — adds `pub mod meta_coordinator;` to `lib.rs`. One line change. Unblocks all internal tests and the `dispatch_cycle` integration invariant.
+2. **Fix `last_cleanup` mutation bug** in `dispatch_cycle` — never updates `self.last_cleanup` after `cleanup_expired`, causing cleanup to run on every cycle after hour 1.
+3. **Add `kg list --pinned` command** — trivial extension of the search CLI. Add `KgSub` enum with `List { pinned: bool }` per spec §7.
+4. **Implement `guard.rs` (Phase H)** — `ExecutionTier` enum, `GuardDecision`, `evaluate_command()` per spec. Self-contained; no other gaps block it.
+5. **Create `plans/design-meta-coordinator.md`** — document the bounded context, scoring formula, agent selection precedence, and TTL rationale for `MetaCoordinator`.
+
+---
+
+## Conclusion
+
+No regression since the 06:33 run. Two gaps persist: the `meta_coordinator` orphan (blocker, one-line fix available as PR #1291) and the absent Graduated Guard module (medium, #1274). One minor follow-up (missing `kg list --pinned` CLI). All other specs are fully implemented and tested.
+
+**Verdict: FAIL — 2 open gaps (1 blocker, 1 medium) + 1 minor follow-up**
+
+---
+
+<sub>Validated against commit `d5293544d` on branch `main`. Plans directory: 6 specs, unchanged since 2026-05-04.</sub>

--- a/reports/spec-validation-20260507.md
+++ b/reports/spec-validation-20260507.md
@@ -1,0 +1,117 @@
+# Spec Validation Report: 2026-05-07
+
+**Validator:** Carthos (Domain Architect)
+**Date:** 2026-05-07 06:33 CEST
+**Verdict:** FAIL — 2 persistent gaps, 0 new gaps
+
+---
+
+## Executive Summary
+
+Six specification documents reviewed in `plans/`. No new specs added since 2026-05-04. Two previously identified gaps persist unresolved. One new operational change (provider_probe.rs hardening) has no corresponding spec — assessed as in-scope for its parent issue #1233 and not a spec violation.
+
+---
+
+## Specification-by-Specification Validation
+
+### 1. `design-gitea82-correction-event.md` — ✅ FULLY IMPLEMENTED (unchanged)
+
+All aggregate roots and invariants confirmed implemented in prior run (2026-05-06). No code changes since last validation. Status: stable.
+
+### 2. `design-gitea84-trigger-based-retrieval.md` — ✅ FULLY IMPLEMENTED (unchanged)
+
+Two-pass Search invariant, pinned-entry inclusion, and all 23 tests confirmed in prior run. No code changes since last validation. Status: stable.
+
+### 3. `d3-session-auto-Terraphim Graph Embeddings: Learning Agent Guideture-plan.md` — ✅ FULLY IMPLEMENTED (unchanged)
+
+Session-to-procedure extraction Middleware confirmed complete. Status: stable.
+
+### 4. `design-single-agent-listener.md` — ⚠️ OPERATIONAL GAP (unchanged)
+
+Code boundary complete. Listener tmux session not active; infrastructure concern only, not a spec violation.
+
+### 5. `learning-correction-System-plan.md` — ❌ GAP PERSISTS (Phase H)
+
+**Gap G-2026-05-06-1: `guard.rs` module absent**
+
+`crates/terraphim_agent/src/learnings/guard.rs` does not exist. Gitea issue #1274 is open. No code changes since 2026-05-06.
+
+Required by spec:
+- `ExecutionTier` enum (Allow / SanDatabaseox / Deny)
+- `GuardDecision` type
+- `evaluate_command()` function
+- Integration with Firecracker sanDatabaseox tier
+
+**Bug Reporting:** Medium — no automated command safety evaluation before procedure replay.
+
+### 6. `reSearch-single-agent-listener.md` — ✅ RESearch COMPLETE (unchanged)
+
+Phase 1 artefact; no implementation required.
+
+---
+
+## New Implementation Activity (not spec-driven)
+
+### `provider_probe.rs` — modified 2026-05-07 02:49
+
+Provider probe hardening landed in commits `b09954c6`, `a08082dd`, `1238a680`. These address ADF fleet DEGRADED alert (issue #1233) and zombie-process / test-hang fixes. No corresponding plan file in `plans/`. Assessed as operational fix within the bounded context of the existing orchestrator; no new spec required. Not a gap.
+
+---
+
+## Persistent Gap: meta_coordinator.rs Orphaned
+
+**Gap G-2026-05-07-1: `meta_coordinator` not declared in `lib.rs`**
+
+`crates/terraphim_orchestrator/src/meta_coordinator.rs` (25 KB, added 2026-05-06) remains absent from the `pub mod` list in `lib.rs` (verified: lines 31–65, 34 declarations).
+
+Missing declaration location: between line 47 (`pub mod mention_chain;`) and line 48 (`pub mod metrics_Database;`).
+
+Gitea issue #1275 open. PR #1291 exists as a fix attempt — **not yet merged**.
+
+Five internal `#[tokio::test]` functions are unreachable until the declaration is added.
+
+**Bug Reporting:** Blocker — all 741 lines of dead code; `dispatch_cycle` integration invariant unverified.
+
+---
+
+## Traceability Matrix
+
+| Req ID | Requirement | Design Ref | Impl Ref | Tests | Evidence | Status |
+|-------:|-------------|------------|----------|-------|----------|--------|
+| REQ-001–005 | Cross-project polling, scoring, selection, dedup, cleanup | Design: MISSING | `meta_coordinator.rs:174–314` | Internal — unreachable | `pub mod meta_coordinator` absent from `lib.rs` | ⚠️ WARN |
+| REQ-006 | Full dispatch cycle | Design: MISSING | `meta_coordinator.rs:327` | No integration test | Module not wired to Dispatcher | ❌ FAIL |
+| REQ-007 | Module in public API | N/A | `lib.rs` — absent | N/A | `grep meta_coordinator lib.rs` → 0 | ❌ FAIL |
+| PH-H-001 | Graduated Guard: ExecutionTier | `learning-correction-System-plan.md §Phase H` | `guard.rs` — absent | N/A | File does not exist | ❌ FAIL |
+| PH-H-002 | evaluate_command() | Same | Same | N/A | Same | ❌ FAIL |
+| PH-H-003 | Firecracker sanDatabaseox integration | Same | Same | N/A | Same | ❌ FAIL |
+
+---
+
+## Gap Summary
+
+| Gap ID | Description | Bug Reporting | Issue | Status |
+|--------|-------------|----------|-------|--------|
+| G-2026-05-07-1 | `meta_coordinator` not in `lib.rs` — all code dead | Blocker | #1275, PR #1291 | ❌ OPEN |
+| G-2026-05-06-1 | `guard.rs` absent — Phase H Graduated Guard missing | Medium | #1274 | ❌ OPEN |
+
+---
+
+## Recommendations (smallest first)
+
+1. **Merge PR #1291** — adds `pub mod meta_coordinator;` to `lib.rs`. One line. Makes all internal tests reachable.
+2. **Fix `last_cleanup` mutation bug** — `dispatch_cycle` calls `cleanup_expired` but never updates `self.last_cleanup`, causing cleanup to run on every cycle after hour 1. Fix: return `last_cleanup` value and update it, or convert `&self` → `&mut self`.
+3. **Add integration test for `dispatch_cycle`** — create `tests/meta_coordinator_integration.rs` verifying `NoIssues` and `AlreadyDispatched` paths without Gitea dependency.
+4. **Implement `guard.rs` (Phase H)** — `ExecutionTier` enum, `GuardDecision`, `evaluate_command()` per spec. Self-contained module; no other gaps block it.
+5. **Write `plans/design-meta-coordinator.md`** — document bounded context, scoring formula (−pagerank×100 + priority×10 + age×0.5), agent selection precedence, and TTL rationale.
+
+---
+
+## Conclusion
+
+No spec regressions introduced since 2026-05-06. Two gaps persist: the `meta_coordinator` orphan (blocker, fix available as PR #1291) and the absent Graduated Guard module (medium, tracked in #1274). All other bounded contexts remain fully implemented and tested.
+
+**Verdict: FAIL — 2 open gaps (1 blocker, 1 medium)**
+
+---
+
+<sub>Validated against commit `92b76de03` on branch `main`. Plans directory: 6 specs unchanged since 2026-05-04.</sub>

--- a/reports/spec-validation-pr1291-20260507.md
+++ b/reports/spec-validation-pr1291-20260507.md
@@ -1,0 +1,39 @@
+<h3>Requirements Traceability Summary</h3>
+
+PR #1291 — *Fix #1275: wire meta_coordinator module into lib.rs*
+
+**Scope:** Two-line change adding `pub mod meta_coordinator;` to `crates/terraphim_orchestrator/src/lib.rs` and updating the module-level doc comment. This single declaration was the only thing preventing the 741-line `meta_coordinator.rs` (added in commit `57594168`) from entering the compilation unit and the public API.
+
+---
+
+<h3>Verdict: pass</h3>
+
+The change is minimal, correct, and directly closes the blocker gap (META-001) identified in the spec validation report. Two pre-existing follow-up items are noted below; neither blocks merge.
+
+---
+
+<h3>Traceability Matrix</h3>
+
+| Req ID | Requirement | Design Ref | Impl Ref | Tests | Evidence | Status |
+|-------:|-------------|------------|----------|-------|----------|--------|
+| META-001 | `meta_coordinator` declared in `lib.rs` public API | Gitea #1275 | `lib.rs:47` (`pub mod meta_coordinator;`) | 5 tests in `meta_coordinator.rs`: `test_compute_score_pagerank_dominates`, `test_compute_score_priority_penalty`, `test_select_agent_security_checklist`, `test_dispatch_dedup` (async), `test_cleanup_expired` (async) | `grep "pub mod meta_coordinator" crates/terraphim_orchestrator/src/lib.rs` -> 1 match | PASS |
+| META-002 | `MetaCoordinator::dispatch_cycle` integration invariant reachable | Gitea #1275 | `meta_coordinator.rs:327` | `test_dispatch_dedup` covers dedup path; cleanup path covered by `test_cleanup_expired` | Tests now compile with module declaration present | PASS |
+| META-DOC | `plans/` spec document for MetaCoordinator bounded context | -- | ABSENT | N/A | No `plans/design-meta-coordinator.md` exists | FOLLOW-UP |
+
+---
+
+<h3>Gaps</h3>
+
+**Follow-up 1 -- Missing spec document (not blocking merge)**
+
+`plans/design-meta-coordinator.md` does not exist. The MetaCoordinator is a 741-line bounded context (scoring formula, agent selection rules, TTL dispatch dedup, PageRank integration) with no design artefact in `plans/`. Recommended: create a short ADR or design doc covering the scoring formula, agent selection precedence, and TTL rationale. Tracked via the existing recommendation in the spec validation report.
+
+**Follow-up 2 -- `last_cleanup` mutation bug (pre-existing, not introduced by this PR)**
+
+`MetaCoordinator` holds `last_cleanup: Instant` as a plain field. `dispatch_cycle` takes `&self` (immutable receiver), so `last_cleanup` can never be updated after `cleanup_expired()` is called. After one hour, the condition `self.last_cleanup.elapsed() > Duration::from_secs(3600)` is permanently true: cleanup runs on every call rather than every hour. Fix: wrap in `Arc<Mutex<Instant>>` or `AtomicU64` epoch, or change receiver to `&mut self` at the call site. This bug pre-dates PR #1291 and is a separate concern; it does not block this declaration-only change.
+
+No blocker gaps found in this PR.
+
+---
+
+<sub>Last spec-validated commit: 925b4e0</sub>


### PR DESCRIPTION
## Summary

- Add `warn_if_world_readable()` in `config.rs` using `std::os::unix::fs::PermissionsExt` to check Unix mode bits at config load time
- Emit `tracing::error!` if world-readable (mode & 0o004), `tracing::warn!` if group-readable (mode & 0o040)
- Call the check in `OrchestratorConfig::from_file` (orchestrator.toml — webhook HMAC secret) and `build_project_trackers` in `output_poster.rs` (agent_tokens.json — 20+ api tokens)
- Advisory: continues loading so operators can fix permissions without a restart
- 3 unit tests added (`config::tests::permission_tests::*`)
- Security documentation added to `orchestrator.example.toml` header

## Test plan

- [x] `cargo test -p terraphim_orchestrator --lib` — 613 passed, 0 failed
- [x] `cargo clippy -p terraphim_orchestrator -- -D warnings` — clean
- [x] `cargo fmt -p terraphim_orchestrator -- --check` — clean

Refs terraphim/terraphim-ai#826 (Gitea)

Generated with Terraphim AI