### PR TITLE
fix(rlm): wire LlmClient through LlmBridge, replace silent stub Refs #1744

### DIFF
--- a/crates/terraphim_rlm/src/error.rs
+++ b/crates/terraphim_rlm/src/error.rs
@@ -132,6 +132,13 @@ pub enum RlmError {
     #[error("LLM call failed: {message}")]
     LlmCallFailed { message: String },
 
+    /// No LLM client configured. Enable the `llm` feature and set an API key
+    /// or run a local Ollama instance.
+    #[error(
+        "No LLM client configured. Enable the `llm` feature (--features llm) and set OPENROUTER_API_KEY or run Ollama on localhost:11434."
+    )]
+    LlmNotConfigured,
+
     /// LLM bridge authentication failed.
     #[error("LLM bridge authentication failed: invalid session token")]
     LlmBridgeAuthFailed,

--- a/crates/terraphim_rlm/src/llm_bridge.rs
+++ b/crates/terraphim_rlm/src/llm_bridge.rs
@@ -123,15 +123,37 @@ pub struct LlmBridge {
     session_manager: Arc<SessionManager>,
     /// Budget trackers per session.
     budget_trackers: dashmap::DashMap<SessionId, Arc<BudgetTracker>>,
+    /// Optional real LLM client.  When `None`, `query()` returns
+    /// `LlmNotConfigured` instead of a silent stub.
+    #[cfg(feature = "llm")]
+    llm_client: Option<Arc<dyn terraphim_service::llm::LlmClient>>,
 }
 
 impl LlmBridge {
-    /// Create a new LLM bridge.
+    /// Create a new LLM bridge without a real LLM client.
+    /// Queries will return `LlmNotConfigured`.
     pub fn new(config: LlmBridgeConfig, session_manager: Arc<SessionManager>) -> Self {
         Self {
             config,
             session_manager,
             budget_trackers: dashmap::DashMap::new(),
+            #[cfg(feature = "llm")]
+            llm_client: None,
+        }
+    }
+
+    /// Create a new LLM bridge with a configured LLM client.
+    #[cfg(feature = "llm")]
+    pub fn with_llm_client(
+        config: LlmBridgeConfig,
+        session_manager: Arc<SessionManager>,
+        client: Arc<dyn terraphim_service::llm::LlmClient>,
+    ) -> Self {
+        Self {
+            config,
+            session_manager,
+            budget_trackers: dashmap::DashMap::new(),
+            llm_client: Some(client),
         }
     }
 
@@ -189,16 +211,34 @@ impl LlmBridge {
 
         let start = std::time::Instant::now();
 
-        // TODO: Actually call the LLM service
-        // For now, return a stub response
-        let response_text = format!(
-            "[LLM Bridge stub] Query: {}...",
-            if request.prompt.len() > 50 {
-                &request.prompt[..50]
-            } else {
-                &request.prompt
+        #[cfg(feature = "llm")]
+        let response_text = match &self.llm_client {
+            Some(client) => {
+                let chat_opts = terraphim_service::llm::ChatOptions {
+                    max_tokens: request.max_tokens.map(|t| t as u32),
+                    temperature: request.temperature,
+                };
+                let messages = vec![serde_json::json!({
+                    "role": "user",
+                    "content": request.prompt
+                })];
+                client
+                    .chat_completion(messages, chat_opts)
+                    .await
+                    .map_err(|e| RlmError::LlmCallFailed {
+                        message: e.to_string(),
+                    })?
             }
-        );
+            None => {
+                return Err(RlmError::LlmNotConfigured);
+            }
+        };
+
+        #[cfg(not(feature = "llm"))]
+        {
+            let _request = request;
+            return Err(RlmError::LlmNotConfigured);
+        }
 
         // Estimate tokens (1 token ~= 4 chars for English text)
         let estimated_tokens = (request.prompt.len() / 4 + response_text.len() / 4) as u64;

--- a/crates/terraphim_rlm/src/rlm.rs
+++ b/crates/terraphim_rlm/src/rlm.rs
@@ -106,7 +106,7 @@ impl TerraphimRlm {
         // Create session manager
         let session_manager = Arc::new(SessionManager::new(config.clone()));
 
-        // Create LLM bridge
+        // Create LLM bridge (bare — caller wires a client via set_llm_client()).
         let llm_bridge_config = LlmBridgeConfig::default();
         let llm_bridge = Arc::new(LlmBridge::new(llm_bridge_config, session_manager.clone()));
 
@@ -793,6 +793,25 @@ impl TerraphimRlm {
             include_history,
             // Command history would be added here if tracking is enabled
         })
+    }
+
+    /// Inject an LLM client from the orchestrator's routing pipeline.
+    ///
+    /// The orchestrator owns provider health, budget tracking, and
+    /// fallback routing.  Call this after construction to wire RLM
+    /// into the existing cost-optimisation stack instead of building
+    /// a standalone client.
+    ///
+    /// Requires the `llm` feature.
+    #[cfg(feature = "llm")]
+    pub fn set_llm_client(&mut self, client: Arc<dyn terraphim_service::llm::LlmClient>) {
+        log::info!("RLM LLM bridge configured with provider: {}", client.name());
+        let bridge_config = LlmBridgeConfig::default();
+        self.llm_bridge = Arc::new(LlmBridge::with_llm_client(
+            bridge_config,
+            self.session_manager.clone(),
+            client,
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary
Replaces the `[LLM Bridge stub]` fake response with proper LLM delegation through the orchestrator's routing pipeline.

## Design
- RLM does NOT build its own LLM client. The orchestrator owns provider health, budget tracking, and fallback routing.
- `TerraphimRlm::set_llm_client()` accepts a pre-routed `Arc<dyn LlmClient>` from the orchestrator.
- Without a client, `LlmBridge::query()` returns `RlmError::LlmNotConfigured` — no more silent fake responses.
- `LlmBridge::with_llm_client()` constructor for the configured path.

## Changes
- `llm_bridge.rs`: struct holds `Option<Arc<dyn LlmClient>>` behind `cfg(feature=llm)`. New `with_llm_client()` constructor. `query()` delegates to real client or returns error.
- `rlm.rs`: new `set_llm_client()` method. `new()` creates bare bridge, waiting for orchestrator injection.
- `error.rs`: new `LlmNotConfigured` variant.

## Orchestrator Integration (separate follow-up)
The orchestrator must call `rlm.set_llm_client(client)` after construction, passing its routed client from `build_llm_from_role()` + provider budget tracking.

Refs terraphim/terraphim-ai#1744 (Gitea)