### PR TITLE
Fix #2131: strip anyhow chain from robot JSON error output

### DIFF
--- a/crates/terraphim_agent/src/main.rs
+++ b/crates/terraphim_agent/src/main.rs
@@ -1319,7 +1319,7 @@ fn emit_robot_error_and_exit(
     if robot || !matches!(format, OutputFormat::Human) {
         use crate::robot::schema::{ResponseMeta, RobotError, RobotResponse};
         let meta = ResponseMeta::new("unknown");
-        let robot_error = RobotError::new(format!("E{:03}", code.code()), format!("{:#}", err));
+        let robot_error = RobotError::new(format!("E{:03}", code.code()), format!("{}", err));
         let response = RobotResponse::<()>::error(vec![robot_error], meta);
         if let Ok(json) = serde_json::to_string(&response) {
             println!("{}", json);


### PR DESCRIPTION
## Summary

Security sentinel (P2, 2026-06-04, PR #2129 review) flagged anyhow chain disclosure in robot-mode JSON error output.

- `format!("{:#}", err)` in `emit_robot_error_and_exit` rendered the full anyhow chain into stdout JSON
- Changed to `format!("{}", err)` — outermost message only, no chain leakage
- `eprintln!("Error: {:#}", err)` on stderr is unchanged (developer-facing)

One-line change in `crates/terraphim_agent/src/main.rs:1322`.

Closes terraphim/terraphim-ai#2131 (Gitea issue)

## Test plan

- [x] `cargo check -p terraphim_agent` passes
- [x] `cargo fmt -p terraphim_agent -- --check` passes
- [x] `cargo clippy -p terraphim_agent` passes
- [ ] `cargo test -p terraphim_agent` passes (running)

@adf:quality-coordinator please review this security fix.