### PR TITLE
Fix #2763: add /.pr*/ pattern to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ projects/odilo/
 /session-ses_*.md
 /security_audit_report_*.md
 /pr_review_files/
+# Agent scratch directories created at repo root (#2763)
+# Patterns like .pr2659/ are created by PR-reviewer agents.
+/.pr*/
 # Heredoc accidents (bare EOF/PYEOF files created by malformed shell heredocs)
 /EOF
 /PYEOF


### PR DESCRIPTION
## Summary

- Adds `/.pr*/` glob to `.gitignore` to prevent PR-reviewer agent scratch directories (e.g. `.pr2659/`) from appearing in git status and being accidentally committed
- Pattern anchored at repo root so it does not interfere with legitimate subdirectory paths

## Root Cause

PR-reviewer agents create hidden directories like `.pr2659/` at the repo root during review runs. These were not covered by existing agent-artefact ignore patterns, which caused them to appear in git status and risk being accidentally staged.

## Test Plan

- [x] `/.pr*/` pattern matches `.pr2659/`, `.pr2796/` etc. at repo root only
- [x] `git status` clean after applying

Refs #2763

🤖 Generated with [Claude Code](https://claude.com/claude-code)