### PR TITLE
Fix #2770: add rust-version = 1.85 to workspace package and all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ default-members = ["terraphim_server"]
 [workspace.package]
 version = "1.20.5"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Terraphim Team <team@terraphim.ai>"]
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/haystack_atlassian/Cargo.toml
+++ b/crates/haystack_atlassian/Cargo.toml
@@ -2,6 +2,7 @@
 name = "atlassian_haystack"
 version = "1.0.0"
 edition.workspace = true
+rust-version.workspace = true
 description = "Atlassian haystack provider for Terraphim AI"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/haystack_discourse/Cargo.toml
+++ b/crates/haystack_discourse/Cargo.toml
@@ -2,6 +2,7 @@
 name = "discourse_haystack"
 version = "1.0.0"
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim <team@terraphim.ai>"]
 description = "A CLI client for fetching Discourse posts and messages"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_agent_application/Cargo.toml
+++ b/crates/terraphim_agent_application/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_agent_application"
 version = "1.0.0"
 edition.workspace = true
+rust-version.workspace = true
 description = "OTP-style application behavior for Terraphim agent system"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/terraphim_automata_py/Cargo.toml
+++ b/crates/terraphim_automata_py/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_automata_py"
 version = "1.0.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Terraphim Contributors"]
 description = "Python bindings for terraphim_automata - Fast autocomplete and text processing for knowledge graphs"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_build_args/Cargo.toml
+++ b/crates/terraphim_build_args/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_build_args"
 version = "1.0.0"
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim Contributors"]
 description = "Build argument management for Terraphim AI projects"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_dsm/Cargo.toml
+++ b/crates/terraphim_dsm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_dsm"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Semantic module grouping using Terraphim knowledge graphs (sentrux companion tool)"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/terraphim_gitea_runner/Cargo.toml
+++ b/crates/terraphim_gitea_runner/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_gitea_runner"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 description = "Native Gitea Actions runner: speaks Gitea RunnerService (Connect-JSON) and executes jobs under Terraphim policy (host/rch), reusing the terraphim_github_runner stack"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/terraphim_github_runner/Cargo.toml
+++ b/crates/terraphim_github_runner/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_github_runner"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 description = "GitHub Actions runner with Firecracker sandbox integration for Terraphim AI"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/terraphim_github_runner_server/Cargo.toml
+++ b/crates/terraphim_github_runner_server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_github_runner_server"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 description = "GitHub Actions runner server with webhook support for Terraphim AI"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/terraphim_lsp/Cargo.toml
+++ b/crates/terraphim_lsp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_lsp"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim Team <team@terraphim.ai>"]
 description = "Language Server Protocol (LSP) implementation for Terraphim AI"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_merge_coordinator/Cargo.toml
+++ b/crates/terraphim_merge_coordinator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_merge_coordinator"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Merge coordinator for Terraphim AI - coordinates code merge operations"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/terraphim_rlm/Cargo.toml
+++ b/crates/terraphim_rlm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_rlm"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim AI Team <team@terraphim.ai>"]
 description = "Recursive Language Model (RLM) orchestration for Terraphim AI"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_rolegraph_py/Cargo.toml
+++ b/crates/terraphim_rolegraph_py/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_rolegraph_py"
 version = "1.0.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Terraphim Contributors"]
 description = "Python bindings for terraphim_rolegraph - Knowledge graph operations for AI agents"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_symphony/Cargo.toml
+++ b/crates/terraphim_symphony/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_symphony"
 version = "1.13.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Terraphim Team <team@terraphim.ai>"]
 description = "Symphony orchestration service - reads issues from trackers and dispatches coding agent sessions"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_tinyclaw/Cargo.toml
+++ b/crates/terraphim_tinyclaw/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_tinyclaw"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Multi-channel AI assistant for Terraphim - Telegram, Discord, and CLI"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/crates/terraphim_update/Cargo.toml
+++ b/crates/terraphim_update/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_update"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim Contributors"]
 description = "Shared auto-update functionality for Terraphim AI binaries"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_validation/Cargo.toml
+++ b/crates/terraphim_validation/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_validation"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim AI Team <team@terraphim.ai>"]
 description = "Release validation system for Terraphim AI"
 documentation = "https://terraphim.ai"

--- a/crates/terraphim_workspace/Cargo.toml
+++ b/crates/terraphim_workspace/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_workspace"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim Team <team@terraphim.ai>"]
 description = "Workspace management for agent execution - lifecycle, hooks, and isolation"
 documentation = "https://terraphim.ai"

--- a/terraphim_ai_nodejs/Cargo.toml
+++ b/terraphim_ai_nodejs/Cargo.toml
@@ -2,6 +2,7 @@
 edition.workspace = true
 name = "terraphim_ai_nodejs"
 version.workspace = true
+rust-version.workspace = true
 description = "Node.js bindings for Terraphim AI"
 documentation = "https://terraphim.ai"
 homepage = "https://terraphim.ai"

--- a/terraphim_firecracker/Cargo.toml
+++ b/terraphim_firecracker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim-firecracker"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim AI Team <team@terraphim.ai>"]
 description = "Sub-2 second VM boot optimization system for Terraphim AI coding assistant"
 documentation = "https://terraphim.ai"

--- a/terraphim_server/Cargo.toml
+++ b/terraphim_server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terraphim_server"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors = ["Terraphim Contributors"]
 description = "Terraphim service handling the core logic of the Terraphim AI."
 documentation = "https://terraphim.ai"


### PR DESCRIPTION
## Summary

- Adds `rust-version = "1.85"` to `[workspace.package]` in root `Cargo.toml`
- Propagates `rust-version.workspace = true` to all 22 workspace member `Cargo.toml` files
- Crates with hardcoded `edition = "2024"` receive an inline `rust-version = "1.85"` to maintain consistency

## Why 1.85

The workspace uses `edition = "2024"` which requires Rust >= 1.85 (stabilised February 2025). This is the tightest defensible lower bound for all workspace members.

## Verification

- `cargo check --workspace` passes clean
- `cargo metadata | jq '.packages[].rust_version' | sort -u` returns `"1.85"` for all workspace members
- All 22 `Cargo.toml` files updated

Fixes #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)