### PR TITLE
fix(lint): resolve clippy --all-targets -D warnings gate (4 findings)

### DIFF
--- a/crates/terraphim_merge_coordinator/src/gitea.rs
+++ b/crates/terraphim_merge_coordinator/src/gitea.rs
@@ -212,18 +212,22 @@ mod tests {
 
     #[test]
     fn open_prs_limit_exceeds_gitea_default_of_50() {
-        assert!(
-            OPEN_PRS_LIMIT > 50,
-            "OPEN_PRS_LIMIT must exceed 50 so PRs beyond position 50 are not silently dropped"
-        );
+        const {
+            assert!(
+                OPEN_PRS_LIMIT > 50,
+                "OPEN_PRS_LIMIT must exceed 50 so PRs beyond position 50 are not silently dropped"
+            )
+        }
     }
 
     #[test]
     fn open_prs_limit_within_gitea_max_page_size() {
-        assert!(
-            OPEN_PRS_LIMIT <= 300,
-            "Gitea max page size is 300; limit must not exceed it"
-        );
+        const {
+            assert!(
+                OPEN_PRS_LIMIT <= 300,
+                "Gitea max page size is 300; limit must not exceed it"
+            )
+        }
     }
 
     #[test]

--- a/crates/terraphim_validation/src/lib.rs
+++ b/crates/terraphim_validation/src/lib.rs
@@ -61,7 +61,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_validation_system_creation() {
-        let system = ValidationSystem::new().unwrap();
-        assert!(true); // Basic creation test
+        let _system = ValidationSystem::new().unwrap();
     }
 }

--- a/crates/terraphim_weather_report/src/main.rs
+++ b/crates/terraphim_weather_report/src/main.rs
@@ -350,10 +350,11 @@ fn print_tier_markdown(tier: &terraphim_weather_report::TierSection) {
             "| {} | {} | `{}` | {} | {} | {} |",
             cond, m.provider, m.model, m.cli, latency, cost
         );
-        if let Some(detail) = &m.detail {
-            if !detail.is_empty() && !detail.starts_with("probe skipped") {
-                println!("| | | | | | *{}* |", detail.replace('|', "\\|"));
-            }
+        if let Some(detail) = &m.detail
+            && !detail.is_empty()
+            && !detail.starts_with("probe skipped")
+        {
+            println!("| | | | | | *{}* |", detail.replace('|', "\\|"));
         }
     }
     println!();

--- a/terraphim_server/src/lib.rs
+++ b/terraphim_server/src/lib.rs
@@ -629,6 +629,39 @@ async fn not_found() -> Response {
     (StatusCode::NOT_FOUND, "404").into_response()
 }
 
+/// Constructs a minimal Axum router suitable for integration tests.
+pub async fn build_router_for_tests() -> Router {
+    use terraphim_config::ConfigBuilder;
+
+    // Create minimal test configuration
+    let mut config = ConfigBuilder::new()
+        .build_default_embedded()
+        .build()
+        .expect("Failed to build test config");
+
+    let config_state = ConfigState::new(&mut config)
+        .await
+        .expect("Failed to create ConfigState");
+
+    let (tx, _rx) = channel::<IndexedDocument>(10);
+
+    // Initialize summarization manager
+    let summarization_manager = Arc::new(SummarizationManager::new(QueueConfig::default()));
+
+    // Initialize workflow management components for tests
+    let workflow_sessions = Arc::new(RwLock::new(HashMap::new()));
+    let (websocket_broadcaster, _) = broadcast::channel(100);
+
+    // Create extended application state for tests
+    let app_state = AppState {
+        config_state,
+        workflow_sessions,
+        websocket_broadcaster,
+    };
+
+    build_router(app_state, tx, summarization_manager, false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -859,37 +892,4 @@ mod tests {
         let desc = result.unwrap();
         assert!(!desc.is_empty());
     }
-}
-
-/// Constructs a minimal Axum router suitable for integration tests.
-pub async fn build_router_for_tests() -> Router {
-    use terraphim_config::ConfigBuilder;
-
-    // Create minimal test configuration
-    let mut config = ConfigBuilder::new()
-        .build_default_embedded()
-        .build()
-        .expect("Failed to build test config");
-
-    let config_state = ConfigState::new(&mut config)
-        .await
-        .expect("Failed to create ConfigState");
-
-    let (tx, _rx) = channel::<IndexedDocument>(10);
-
-    // Initialize summarization manager
-    let summarization_manager = Arc::new(SummarizationManager::new(QueueConfig::default()));
-
-    // Initialize workflow management components for tests
-    let workflow_sessions = Arc::new(RwLock::new(HashMap::new()));
-    let (websocket_broadcaster, _) = broadcast::channel(100);
-
-    // Create extended application state for tests
-    let app_state = AppState {
-        config_state,
-        workflow_sessions,
-        websocket_broadcaster,
-    };
-
-    build_router(app_state, tx, summarization_manager, false)
 }


### PR DESCRIPTION
## Summary
Fixes all 4 clippy lint failures surfaced by \`cargo clippy --workspace --all-targets -- -D warnings\` as filed in Gitea #2933.

- **weather_report** `collapsible_if`: collapse nested `if let Some(detail)` + `if !detail.is_empty()` into let-chain
- **merge_coordinator** `assertions_on_constants` (×2): wrap compile-time const assertions in `const { assert!(...) }` blocks
- **terraphim_validation** `assertions_on_constants`: remove dead `assert!(true)` from test
- **terraphim_server** `items_after_test_module`: move `build_router_for_tests` before `#[cfg(test)] mod tests`

## Test plan
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` passes clean
- [x] \`cargo fmt --all -- --check\` passes
- [x] \`cargo test --workspace\` passes (1114 tests)

Closes terraphim/terraphim-ai#2933 (Gitea)

🤖 Generated with [Terraphim AI](https://github.com/terraphim/terraphim-ai)