### PR TITLE
fix(tests): use portpicker for ephemeral port in default_role_integration_test

### DIFF
--- a/terraphim_server/tests/default_role_integration_test.rs
+++ b/terraphim_server/tests/default_role_integration_test.rs
@@ -115,8 +115,9 @@ async fn test_default_role_ripgrep_integration() {
     log::info!("✅ Default role configuration validated");
     log::info!("   - Ripgrep haystack: {}", ripgrep_haystack.location);
 
-    // Start server on a test port
-    let server_addr = "127.0.0.1:8085".parse().unwrap();
+    // Start server on an ephemeral port to avoid address-already-in-use conflicts
+    let port = portpicker::pick_unused_port().expect("No unused ports available");
+    let server_addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
     let server_handle = tokio::spawn(async move {
         if let Err(e) = axum_server(server_addr, config_state).await {
             log::error!("Server error: {:?}", e);
@@ -129,7 +130,7 @@ async fn test_default_role_ripgrep_integration() {
 
     let client = terraphim_service::http_client::create_default_client()
         .expect("Failed to create HTTP client");
-    let base_url = "http://127.0.0.1:8085";
+    let base_url = format!("http://127.0.0.1:{}", port);
 
     // Test 1: Health check
     log::info!("🔍 Testing server health...");


### PR DESCRIPTION
## Summary

- Replaces hardcoded port `8085` in `terraphim_server/tests/default_role_integration_test.rs` with `portpicker::pick_unused_port()`.
- `portpicker` is already a crate dependency (in `[dependencies]`, used by `tests/server.rs`).
- No other changes — one-line root cause, minimal diff.

## Root cause

`"127.0.0.1:8085".parse().unwrap()` is a fixed address. When the OS kernel has not fully released the port from a previous test run, `TcpListener::bind` fails with `EADDRINUSE` (os error 98), producing a flaky `Server error: ApiError(500, Address already in use)`. The pattern was already established correctly in `tests/server.rs`.

## Verification

```
cargo test -p terraphim_server --test default_role_integration_test
# running 2 tests
# test test_default_role_config_structure ... ok
# test test_default_role_ripgrep_integration ... ok
# test result: ok. 2 passed; 0 failed; 0 ignored
```

```
cargo clippy -p terraphim_server -- -D warnings  # clean
cargo fmt --all -- --check                        # clean
```

Refs terraphim/terraphim-ai#2947 (Gitea)