### PR TITLE
Fix #911: use hex::encode for sha2 0.11 output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9576,6 +9576,7 @@ dependencies = [
  "dialoguer",
  "dirs 5.0.1",
  "flate2",
+ "hex",
  "jiff",
  "self_update",
  "semver",

--- a/crates/terraphim_update/Cargo.toml
+++ b/crates/terraphim_update/Cargo.toml
@@ -29,6 +29,7 @@ chrono = { workspace = true }
 
 semver = "1.0"
 sha2 = "0.11"
+hex = "0.4"
 ureq = "2.9"
 dirs = "5.0"
 dialoguer = "0.12"

--- a/crates/terraphim_update/src/rollback.rs
+++ b/crates/terraphim_update/src/rollback.rs
@@ -47,7 +47,7 @@ impl Backup {
         let mut hasher = Sha256::new();
         hasher.update(&contents);
         let result = hasher.finalize();
-        Ok(format!("{:x}", result))
+        Ok(hex::encode(result))
     }
 
     /// Verify that the backup file is intact
@@ -185,7 +185,7 @@ impl BackupManager {
         let mut hasher = Sha256::new();
         hasher.update(&contents);
         let result = hasher.finalize();
-        Ok(format!("{:x}", result))
+        Ok(hex::encode(result))
     }
 
     /// Rotate backups to maintain the maximum count


### PR DESCRIPTION
Fixes the compile regression introduced by bumping sha2 to 0.11 in #911.

- sha2::Sha256::finalize() output no longer implements LowerHex via format!("{:x}", ...).
- Add hex = "0.4" dependency and encode the digest explicitly.

Refs #911