### PR TITLE
Fix #920: bump ureq to 3.3.0 and migrate downloader API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9582,7 +9582,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "ureq",
+ "ureq 2.12.1",
  "zip 8.6.0",
  "zipsign-api",
 ]
@@ -9610,7 +9610,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "ureq",
+ "ureq 3.3.0",
  "zip 8.6.0",
  "zipsign-api",
 ]
@@ -10597,6 +10597,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10620,6 +10649,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/terraphim_update/Cargo.toml
+++ b/crates/terraphim_update/Cargo.toml
@@ -30,7 +30,7 @@ chrono = { workspace = true }
 semver = "1.0"
 sha2 = "0.11"
 hex = "0.4"
-ureq = "2.9"
+ureq = "3.3"
 dirs = "5.0"
 dialoguer = "0.12"
 # zipsign-api for signature verification (also pulled by self_update)

--- a/crates/terraphim_update/src/downloader.rs
+++ b/crates/terraphim_update/src/downloader.rs
@@ -8,7 +8,7 @@
 //! - Timeout handling
 
 use anyhow::{Result, anyhow};
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
@@ -204,24 +204,30 @@ fn perform_download(
     output_path: &std::path::Path,
     config: &DownloadConfig,
 ) -> Result<u64> {
-    let response = ureq::get(url)
-        .timeout(config.timeout)
+    let agent_config = ureq::Agent::config_builder()
+        .timeout_global(Some(config.timeout))
+        .http_status_as_error(false)
+        .build();
+    let agent = ureq::Agent::new_with_config(agent_config);
+
+    let response = agent
+        .get(url)
         .call()
         .map_err(|e| anyhow!("HTTP request failed: {}", e))?;
 
-    if response.status() != 200 {
-        return Err(anyhow!(
-            "HTTP error: {} {}",
-            response.status(),
-            response.status_text()
-        ));
+    let status = response.status();
+    if status.as_u16() != 200 {
+        return Err(anyhow!("HTTP error: {}", status));
     }
 
     let content_length = response
-        .header("Content-Length")
+        .headers()
+        .get("Content-Length")
+        .and_then(|h| h.to_str().ok())
         .and_then(|h| h.parse::<u64>().ok());
 
-    let mut reader = response.into_reader();
+    let mut body = response.into_body();
+    let mut reader = body.as_reader();
 
     let mut file = std::fs::File::create(output_path)?;
     let mut total_bytes = 0u64;


### PR DESCRIPTION
Supersedes and closes #920.

ureq 3.x introduces breaking API changes:
- timeout is now configured on the Agent via ConfigBuilder
- responses are http::Response<Body>
- Content-Length is read from headers()
- body is streamed via Body::as_reader()

This PR updates crates/terraphim_update to compile and pass tests with ureq 3.3.0.

Closes #920