### PR TITLE
ci: build docs from SUMMARY.md rather than by walking the directory

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -59,10 +59,15 @@ jobs:
           ls -la
           echo "DEBUG: Checking md-book binary:"
           ls -la /tmp/md-book/target/release/ || echo "md-book binary not found"
-          echo "DEBUG: Building with md-book fork..."
+          echo "Building with md-book (SUMMARY.md-driven)"
           rm -rf book/
-          /tmp/md-book/target/release/md-book -i . -o book || true
-          echo "DEBUG: Build completed with exit code: $?"
+          # `build .` reads book.toml, so it honours `src` and the SUMMARY.md
+          # ordering. The old `-i . -o book` pointed at the docs root, which has
+          # no SUMMARY.md, so md-book fell back to walking the directory and
+          # published 574 pages — archives, research notes and artefacts
+          # included — in path order rather than the 59 the summary declares.
+          /tmp/md-book/target/release/md-book build .
+          echo "Pages built: $(find book -name '*.html' | wc -l)"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
## What

`deploy-docs.yml` invokes md-book as `md-book -i . -o book`. That points at the docs root, which has no `SUMMARY.md`, so md-book falls back to walking the directory: **574 pages** in path order, publishing `archive/`, `artifacts/` and research notes alongside the real documentation.

`md-book build .` reads `book.toml`, so it honours `src = "src"` and the 118-line `SUMMARY.md`: **59 pages**, in the declared order, with the part titles and the `[output.html.fold]` the config already asks for. Output still lands in `docs/book/`, which is what the upload step expects.

Also drops the `|| true`, which was hiding build failures behind a green job and a stale artefact.

## Why now

terraphim/md-book#27 just landed, adding the `SUMMARY.md` book model and the `build [dir]` subcommand. This workflow clones md-book from `main`, so it picks that up automatically.

That PR also fixes two things visible on docs.terraphim.ai today:

- `git-repository-url` and `edit-url-template` are set in `docs/book.toml` but md-book knew only its own key names, so **the repository and edit links have been silently missing**. Both mdBook spellings are now accepted.
- A `SUMMARY.md` entry pointing at `../CLOUDFLARE_DEPLOYMENT.md` (a file beside `book.toml`) used to abort the summary-driven build; containment is now scoped to the book directory rather than `src/`.

## Verification

Built this repo's docs with the merged md-book:

```
md-book build .   ->  Total pages: 59, into docs/book/
```

Sidebar carries the SUMMARY part titles (Crates Overview, Components, Integrations); orphaned files under `docs/src` are reported rather than silently published.

Note `mathjax-support = true` in `docs/book.toml` warns as unimplemented — no content in `docs/src` uses maths, so nothing is lost; remove the key or leave it as a marker.