### PR TITLE
Revert: restore the full docs page set (574, not 59)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -59,15 +59,10 @@ jobs:
           ls -la
           echo "DEBUG: Checking md-book binary:"
           ls -la /tmp/md-book/target/release/ || echo "md-book binary not found"
-          echo "Building with md-book (SUMMARY.md-driven)"
+          echo "DEBUG: Building with md-book fork..."
           rm -rf book/
-          # `build .` reads book.toml, so it honours `src` and the SUMMARY.md
-          # ordering. The old `-i . -o book` pointed at the docs root, which has
-          # no SUMMARY.md, so md-book fell back to walking the directory and
-          # published 574 pages — archives, research notes and artefacts
-          # included — in path order rather than the 59 the summary declares.
-          /tmp/md-book/target/release/md-book build .
-          echo "Pages built: $(find book -name '*.html' | wc -l)"
+          /tmp/md-book/target/release/md-book -i . -o book || true
+          echo "DEBUG: Build completed with exit code: $?"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
Reverts #960. The live site went from 574 pages to 59 on the last deploy, and that removed real content, not just archives: `PERFORMANCE_BENCHMARKING_README`, the research and validation documents at the docs root, and 165 archived pages that were nonetheless published and linkable. Anything pointing at them now 404s.

My reasoning in #960 was that `SUMMARY.md` declares 59 chapters and the rest was noise. That was a content decision dressed up as a build-tool upgrade, and it wasn't mine to make. The site has published everything under `docs/` for as long as md-book has built it.

Restoring first. If narrowing the published surface is wanted, it should be a deliberate change with the pages either added to `SUMMARY.md` or explicitly retired.

md-book 0.2.0 itself is unaffected by this revert — the directory-walk path is fully supported and tested.